### PR TITLE
feat: Support serializing and deserializing LoRA adapters

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -222,7 +222,7 @@ steps:
     - python3 offline_inference/llm_engine_example.py
     - python3 offline_inference/vision_language.py
     - python3 offline_inference/vision_language_multi_image.py
-    - python3 other/tensorize_vllm_model.py --model facebook/opt-125m serialize --serialized-directory /tmp/ --suffix v1 && python3 other/tensorize_vllm_model.py --model facebook/opt-125m deserialize --path-to-tensors /tmp/vllm/facebook/opt-125m/v1/model.tensors
+    - python3 other/tensorize_vllm_model.py --model meta-llama/Llama-2-7b-hf --lora-path yard1/llama-2-7b-sql-lora-test serialize --serialized-directory /tmp/ --suffix v1 && python3 other/tensorize_vllm_model.py --model meta-llama/Llama-2-7b-hf --lora-path yard1/llama-2-7b-sql-lora-test deserialize --path-to-tensors /tmp/vllm/meta-llama/Llama-2-7b-hf/v1/model.tensors
     - python3 offline_inference/encoder_decoder.py
     - python3 offline_inference/classification.py
     - python3 offline_inference/embedding.py
@@ -254,7 +254,7 @@ steps:
   - vllm/model_executor/guided_decoding
   - tests/test_logits_processor
   - tests/model_executor/test_guided_processors
-  commands: 
+  commands:
     - pytest -v -s test_logits_processor.py
     - pytest -v -s model_executor/test_guided_processors.py
 

--- a/examples/other/tensorize_vllm_model.py
+++ b/examples/other/tensorize_vllm_model.py
@@ -8,10 +8,9 @@ import uuid
 
 from vllm import LLM
 from vllm.engine.arg_utils import EngineArgs
-from vllm.model_executor.model_loader.tensorizer import (TensorizerArgs,
-                                                         TensorizerConfig,
-                                                         tensorize_vllm_model,
-                                                         tensorize_lora_adapter)
+from vllm.model_executor.model_loader.tensorizer import (
+    TensorizerArgs, TensorizerConfig, tensorize_lora_adapter,
+    tensorize_vllm_model)
 from vllm.utils import FlexibleArgumentParser
 
 # yapf conflicts with isort for this docstring
@@ -197,9 +196,9 @@ def deserialize():
             stop=["[/assistant]"]
         )
 
+        # Truncating this as the extra text isn't necessary
         prompts = [
-            "[user] Write a SQL query to answer the question based on the table schema.\n\n context: CREATE TABLE table_name_74 (icao VARCHAR, airport VARCHAR)\n\n question: Name the ICAO for lilongwe international airport [/user] [assistant]",
-            "[user] Write a SQL query to answer the question based on the table schema.\n\n context: CREATE TABLE table_name_11 (nationality VARCHAR, elector VARCHAR)\n\n question: When Anchero Pantaleone was the elector what is under nationality? [/user] [assistant]",
+            "[user] Write a SQL query to answer the question based on ..."
         ]
 
         # Test LoRA load

--- a/examples/other/tensorize_vllm_model.py
+++ b/examples/other/tensorize_vllm_model.py
@@ -6,8 +6,9 @@ import json
 import os
 import uuid
 
-from vllm import LLM
+from vllm import LLM, SamplingParams
 from vllm.engine.arg_utils import EngineArgs
+from vllm.lora.request import LoRARequest
 from vllm.model_executor.model_loader.tensorizer import (
     TensorizerArgs, TensorizerConfig, tensorize_lora_adapter,
     tensorize_vllm_model)
@@ -108,6 +109,9 @@ def parse_args():
         "use it.")
     parser = EngineArgs.add_cli_args(parser)
 
+    # TODO: Provide example code for its usage here, both for invoking
+    #  this is in the context of this script, and using LoRA with tensorizer
+    #  generally.
     parser.add_argument(
         "--lora-path",
         type=str,
@@ -181,8 +185,6 @@ def parse_args():
 
 def deserialize():
     if args.lora_path:
-        from vllm import SamplingParams
-        from vllm.lora.request import LoRARequest
 
         llm = LLM(model=args.model,
                   load_format="tensorizer",

--- a/tests/entrypoints/openai/test_tensorizer_entrypoint.py
+++ b/tests/entrypoints/openai/test_tensorizer_entrypoint.py
@@ -1,0 +1,113 @@
+import json
+import tempfile
+import weakref
+
+import openai
+import pytest
+import pytest_asyncio
+import torch.cuda
+
+from vllm import LLM, SamplingParams
+from vllm.engine.arg_utils import EngineArgs
+from vllm.lora.request import LoRARequest
+from vllm.model_executor.model_loader.tensorizer import (
+    TensorizerConfig, tensorize_lora_adapter, tensorize_vllm_model)
+
+from ...utils import RemoteOpenAIServer
+
+MODEL_NAME = "meta-llama/Llama-2-7b-hf"
+LORA_PATH = "yard1/llama-2-7b-sql-lora-test"
+
+
+@pytest.fixture(scope="module")
+def tmp_dir():
+    tmp_dir = tempfile.TemporaryDirectory()
+
+    def cleanup():
+        tmp_dir.cleanup()
+
+    weakref.finalize(tmp_dir, cleanup)
+
+    yield tmp_dir
+
+    cleanup()
+
+
+@pytest.fixture(scope="module")
+def tensorize_model_and_lora(tmp_dir):
+    model_uri = tmp_dir.name + "/model.tensors"
+    tensorizer_config = TensorizerConfig(tensorizer_uri=model_uri)
+    args = EngineArgs(model=MODEL_NAME, )
+
+    tensorize_lora_adapter(LORA_PATH, tensorizer_config)
+    tensorize_vllm_model(args, tensorizer_config)
+
+    torch.cuda.empty_cache()
+
+
+@pytest.fixture(scope="module")
+def server(tmp_dir, tensorize_model_and_lora):
+    model_uri = tmp_dir.name + "/model.tensors"
+    model_loader_extra_config = {
+        "tensorizer_uri": model_uri,
+    }
+
+    ## Start OpenAI API server
+    args = [
+        "--load-format", "tensorizer", "--model-loader-extra-config",
+        json.dumps(model_loader_extra_config), "--enable-lora"
+    ]
+
+    with RemoteOpenAIServer(MODEL_NAME, args) as remote_server:
+        yield remote_server
+
+
+@pytest_asyncio.fixture
+async def client(server):
+    async with server.get_async_client() as async_client:
+        yield async_client
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
+async def test_single_completion(client: openai.AsyncOpenAI, model_name: str):
+    completion = await client.completions.create(model=model_name,
+                                                 prompt="Hello, my name is",
+                                                 max_tokens=5,
+                                                 temperature=0.0)
+
+    assert completion.id is not None
+    assert completion.choices is not None and len(completion.choices) == 1
+    assert completion.model == MODEL_NAME
+    assert len(completion.choices) == 1
+    assert len(completion.choices[0].text) >= 5
+    assert completion.choices[0].finish_reason == "length"
+    assert completion.usage == openai.types.CompletionUsage(
+        completion_tokens=5, prompt_tokens=6, total_tokens=11)
+
+
+def test_confirm_deserialize_and_serve(tmp_dir, tensorize_model_and_lora):
+    model_uri = tmp_dir.name + "/model.tensors"
+    llm = LLM(
+        MODEL_NAME,
+        load_format="tensorizer",
+        model_loader_extra_config=TensorizerConfig(tensorizer_uri=model_uri),
+        enable_lora=True)
+
+    sampling_params = SamplingParams(temperature=0,
+                                     max_tokens=256,
+                                     stop=["[/assistant]"])
+
+    prompts = [
+        "[user] Write a SQL query to answer the question based on the table schema.\n\n context: CREATE TABLE table_name_74 (icao VARCHAR, airport VARCHAR)\n\n question: Name the ICAO for lilongwe international airport [/user] [assistant]",  # noqa: E501
+        "[user] Write a SQL query to answer the question based on the table schema.\n\n context: CREATE TABLE table_name_11 (nationality VARCHAR, elector VARCHAR)\n\n question: When Anchero Pantaleone was the elector what is under nationality? [/user] [assistant]",  # noqa: E501
+    ]
+
+    llm.generate(prompts,
+                 sampling_params,
+                 lora_request=LoRARequest("sql-lora",
+                                          1,
+                                          tmp_dir.name,
+                                          tensorizer_config=TensorizerConfig(
+                                              tensorizer_uri=tmp_dir.name +
+                                              "/adapter_model.tensors")))

--- a/tests/entrypoints/openai/test_tensorizer_entrypoint.py
+++ b/tests/entrypoints/openai/test_tensorizer_entrypoint.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import tempfile
 import weakref
@@ -109,5 +111,4 @@ def test_confirm_deserialize_and_serve(tmp_dir, tensorize_model_and_lora):
                                           1,
                                           tmp_dir.name,
                                           tensorizer_config=TensorizerConfig(
-                                              tensorizer_uri=tmp_dir.name +
-                                              "/adapter_model.tensors")))
+                                              tensorizer_uri=model_uri)))

--- a/tests/entrypoints/openai/test_tensorizer_entrypoint.py
+++ b/tests/entrypoints/openai/test_tensorizer_entrypoint.py
@@ -43,8 +43,9 @@ def model_uri(tmp_dir):
 
 
 @pytest.fixture(scope="module")
-def tensorize_model_and_lora(model_uri):
-    tensorizer_config = TensorizerConfig(tensorizer_uri=model_uri)
+def tensorize_model_and_lora(tmp_dir, model_uri):
+    tensorizer_config = TensorizerConfig(tensorizer_uri=model_uri,
+                                         lora_dir=tmp_dir)
     args = EngineArgs(model=MODEL_NAME)
 
     tensorize_lora_adapter(LORA_PATH, tensorizer_config)
@@ -98,11 +99,11 @@ async def test_single_completion(client: openai.AsyncOpenAI, model_name: str):
 
 def test_confirm_deserialize_and_serve(model_uri, tmp_dir,
                                        tensorize_model_and_lora):
-    llm = LLM(
-        MODEL_NAME,
-        load_format="tensorizer",
-        model_loader_extra_config=TensorizerConfig(tensorizer_uri=model_uri),
-        enable_lora=True)
+    tc = TensorizerConfig(tensorizer_uri=model_uri, lora_dir=tmp_dir)
+    llm = LLM(MODEL_NAME,
+              load_format="tensorizer",
+              model_loader_extra_config=tc,
+              enable_lora=True)
 
     sampling_params = SamplingParams(temperature=0,
                                      max_tokens=256,
@@ -118,5 +119,4 @@ def test_confirm_deserialize_and_serve(model_uri, tmp_dir,
                  lora_request=LoRARequest("sql-lora",
                                           1,
                                           tmp_dir,
-                                          tensorizer_config=TensorizerConfig(
-                                              tensorizer_uri=model_uri)))
+                                          tensorizer_config=tc))

--- a/tests/entrypoints/openai/test_tensorizer_entrypoint.py
+++ b/tests/entrypoints/openai/test_tensorizer_entrypoint.py
@@ -2,7 +2,6 @@
 
 import json
 import tempfile
-import weakref
 
 import openai
 import pytest
@@ -19,6 +18,9 @@ from ...utils import RemoteOpenAIServer
 
 MODEL_NAME = "meta-llama/Llama-2-7b-hf"
 LORA_PATH = "yard1/llama-2-7b-sql-lora-test"
+
+# TODO: The frequent need to fetch the model_uri by doing
+#  `foo = tmp_dir.name + bar` means this should be its own fixture
 
 
 @pytest.fixture(scope="module")

--- a/tests/entrypoints/openai/test_tensorizer_entrypoint.py
+++ b/tests/entrypoints/openai/test_tensorizer_entrypoint.py
@@ -23,23 +23,15 @@ LORA_PATH = "yard1/llama-2-7b-sql-lora-test"
 
 @pytest.fixture(scope="module")
 def tmp_dir():
-    tmp_dir = tempfile.TemporaryDirectory()
-
-    def cleanup():
-        tmp_dir.cleanup()
-
-    weakref.finalize(tmp_dir, cleanup)
-
-    yield tmp_dir
-
-    cleanup()
+    with tempfile.TemporaryDirectory() as path:
+        yield path
 
 
 @pytest.fixture(scope="module")
 def tensorize_model_and_lora(tmp_dir):
     model_uri = tmp_dir.name + "/model.tensors"
     tensorizer_config = TensorizerConfig(tensorizer_uri=model_uri)
-    args = EngineArgs(model=MODEL_NAME, )
+    args = EngineArgs(model=MODEL_NAME)
 
     tensorize_lora_adapter(LORA_PATH, tensorizer_config)
     tensorize_vllm_model(args, tensorizer_config)

--- a/tests/tensorizer_loader/test_tensorizer.py
+++ b/tests/tensorizer_loader/test_tensorizer.py
@@ -13,17 +13,15 @@ import pytest
 import torch
 from huggingface_hub import snapshot_download
 
-from vllm import SamplingParams
+from vllm import LLM, SamplingParams
 from vllm.engine.arg_utils import EngineArgs
+from vllm.lora.request import LoRARequest
 # yapf conflicts with isort for this docstring
 # yapf: disable
-from vllm.model_executor.model_loader.tensorizer import (TensorizerConfig,
-                                                         TensorSerializer,
-                                                         is_vllm_tensorized,
-                                                         load_with_tensorizer,
-                                                         open_stream,
-                                                         serialize_vllm_model,
-                                                         tensorize_vllm_model)
+from vllm.model_executor.model_loader.tensorizer import (
+    TensorizerConfig, TensorSerializer, is_vllm_tensorized,
+    load_with_tensorizer, open_stream, serialize_vllm_model,
+    tensorize_lora_adapter, tensorize_vllm_model)
 # yapf: enable
 from vllm.utils import PlaceholderModule, import_from_path
 
@@ -352,32 +350,23 @@ def test_vllm_tensorized_model_has_same_outputs(vllm_runner, tmp_path):
 
 
 def test_serialize_and_deserialize_lora(tmp_path):
-    import shutil
 
-    from safetensors.torch import load_file
+    model_ref = "meta-llama/Llama-2-7b-hf"
+    lora_path = "yard1/llama-2-7b-sql-lora-test"
+    model_uri = tmp_path / (model_ref + ".tensors")
+    tensorizer_config = TensorizerConfig(tensorizer_uri=str(model_uri))
+    args = EngineArgs(model=model_ref)
 
-    from vllm import LLM, SamplingParams
-    from vllm.lora.request import LoRARequest
+    tensorize_lora_adapter(lora_path, tensorizer_config)
+    tensorize_vllm_model(args, tensorizer_config)
 
-    sql_lora_files = snapshot_download(
-        repo_id="yard1/llama-2-7b-sql-lora-test")
-    tensor_path = os.path.join(sql_lora_files, "adapter_model.safetensors")
-    config_path = os.path.join(sql_lora_files, "adapter_config.json")
-    tensors = load_file(tensor_path)
+    gc.collect()
+    torch.cuda.empty_cache()
 
-    # TODO: This will not work for non-local saving. Use `open_stream`
-    #  to save this json. Pretty sure there are examples of this
-    #  in the tensorizer repo
-    shutil.copy(config_path, tmp_path / "adapter_config.json")
-
-    tensorizer_uri = tmp_path / "adapter_model.tensors"
-    serializer = TensorSerializer(tensorizer_uri)
-    serializer.write_state_dict(tensors)
-    serializer.close()
-
-    # Now, load it
-
-    loaded_vllm_model = LLM(model="meta-llama/Llama-2-7b-hf", enable_lora=True)
+    loaded_vllm_model = LLM(model="meta-llama/Llama-2-7b-hf",
+                            load_format="tensorizer",
+                            model_loader_extra_config=tensorizer_config,
+                            enable_lora=True)
     sampling_params = SamplingParams(temperature=0,
                                      max_tokens=256,
                                      stop=["[/assistant]"])
@@ -387,13 +376,11 @@ def test_serialize_and_deserialize_lora(tmp_path):
         "[user] Write a SQL query to answer the question based on the table schema.\n\n context: CREATE TABLE table_name_11 (nationality VARCHAR, elector VARCHAR)\n\n question: When Anchero Pantaleone was the elector what is under nationality? [/user] [assistant]",  # noqa: E501
     ]
 
-    lora_path = tmp_path
-    lora_tensorizer_uri = str(tmp_path) + "/model.tensors"
+    lora_path = tensorizer_config.tensorizer_dir
     loaded_vllm_model.generate(prompts,
                                sampling_params,
                                lora_request=LoRARequest(
                                    "sql-lora",
                                    1,
                                    lora_path,
-                                   tensorizer_config=TensorizerConfig(
-                                       tensorizer_uri=lora_tensorizer_uri, )))
+                                   tensorizer_config=tensorizer_config))

--- a/tests/tensorizer_loader/test_tensorizer.py
+++ b/tests/tensorizer_loader/test_tensorizer.py
@@ -352,14 +352,15 @@ def test_vllm_tensorized_model_has_same_outputs(vllm_runner, tmp_path):
 
 
 def test_serialize_lora_model(tmp_path):
-    from safetensors.torch import load_file
-    from vllm.lora.models import LoRAModel
-    import json
     import shutil
-    from vllm.lora.request import LoRARequest
-    from vllm import LLM, SamplingParams
 
-    sql_lora_files = snapshot_download(repo_id="yard1/llama-2-7b-sql-lora-test")
+    from safetensors.torch import load_file
+
+    from vllm import LLM, SamplingParams
+    from vllm.lora.request import LoRARequest
+
+    sql_lora_files = snapshot_download(
+        repo_id="yard1/llama-2-7b-sql-lora-test")
     tensor_path = os.path.join(sql_lora_files, "adapter_model.safetensors")
     config_path = os.path.join(sql_lora_files, "adapter_config.json")
     tensors = load_file(tensor_path)
@@ -371,34 +372,25 @@ def test_serialize_lora_model(tmp_path):
     serializer.write_state_dict(tensors)
     serializer.close()
 
-
     # Now, load it
 
     loaded_vllm_model = LLM(model="meta-llama/Llama-2-7b-hf", enable_lora=True)
-    sampling_params = SamplingParams(
-        temperature=0,
-        max_tokens=256,
-        stop=["[/assistant]"]
-    )
+    sampling_params = SamplingParams(temperature=0,
+                                     max_tokens=256,
+                                     stop=["[/assistant]"])
 
     prompts = [
-        "[user] Write a SQL query to answer the question based on the table schema.\n\n context: CREATE TABLE table_name_74 (icao VARCHAR, airport VARCHAR)\n\n question: Name the ICAO for lilongwe international airport [/user] [assistant]",
-        "[user] Write a SQL query to answer the question based on the table schema.\n\n context: CREATE TABLE table_name_11 (nationality VARCHAR, elector VARCHAR)\n\n question: When Anchero Pantaleone was the elector what is under nationality? [/user] [assistant]",
+        "[user] Write a SQL query to answer the question based on the table schema.\n\n context: CREATE TABLE table_name_74 (icao VARCHAR, airport VARCHAR)\n\n question: Name the ICAO for lilongwe international airport [/user] [assistant]",  # noqa: E501
+        "[user] Write a SQL query to answer the question based on the table schema.\n\n context: CREATE TABLE table_name_11 (nationality VARCHAR, elector VARCHAR)\n\n question: When Anchero Pantaleone was the elector what is under nationality? [/user] [assistant]",  # noqa: E501
     ]
 
     lora_path = tmp_path
     lora_tensorizer_uri = str(tmp_path) + "/model.tensors"
-    outputs = loaded_vllm_model.generate(
-        prompts,
-        sampling_params,
-        lora_request=LoRARequest("sql-lora",
-                                 1,
-                                 lora_path,
-                                 tensorizer_config = TensorizerConfig(
-                                     tensorizer_uri = lora_tensorizer_uri,
-                                 ))
-    )
-
-
-
-
+    loaded_vllm_model.generate(prompts,
+                               sampling_params,
+                               lora_request=LoRARequest(
+                                   "sql-lora",
+                                   1,
+                                   lora_path,
+                                   tensorizer_config=TensorizerConfig(
+                                       tensorizer_uri=lora_tensorizer_uri, )))

--- a/tests/tensorizer_loader/test_tensorizer.py
+++ b/tests/tensorizer_loader/test_tensorizer.py
@@ -351,7 +351,7 @@ def test_vllm_tensorized_model_has_same_outputs(vllm_runner, tmp_path):
         assert outputs == deserialized_outputs
 
 
-def test_serialize_lora_model(tmp_path):
+def test_serialize_and_deserialize_lora_model(tmp_path):
     import shutil
 
     from safetensors.torch import load_file

--- a/tests/tensorizer_loader/test_tensorizer.py
+++ b/tests/tensorizer_loader/test_tensorizer.py
@@ -359,15 +359,7 @@ def test_serialize_lora_model(tmp_path):
     from vllm.lora.request import LoRARequest
     from vllm import LLM, SamplingParams
 
-    EMBEDDING_MODULES = {
-        "embed_tokens": "input_embeddings",
-        "lm_head": "output_embeddings",
-    }
-
-    EMBEDDING_PADDING_MODULES = ["lm_head"]
-
     sql_lora_files = snapshot_download(repo_id="yard1/llama-2-7b-sql-lora-test")
-    device = "cuda"
     tensor_path = os.path.join(sql_lora_files, "adapter_model.safetensors")
     config_path = os.path.join(sql_lora_files, "adapter_config.json")
     tensors = load_file(tensor_path)
@@ -395,10 +387,16 @@ def test_serialize_lora_model(tmp_path):
     ]
 
     lora_path = tmp_path
+    lora_tensorizer_uri = str(tmp_path) + "/model.tensors"
     outputs = loaded_vllm_model.generate(
         prompts,
         sampling_params,
-        lora_request=LoRARequest("sql-lora", 1, lora_path)
+        lora_request=LoRARequest("sql-lora",
+                                 1,
+                                 lora_path,
+                                 tensorizer_config = TensorizerConfig(
+                                     tensorizer_uri = lora_tensorizer_uri,
+                                 ))
     )
 
 

--- a/tests/tensorizer_loader/test_tensorizer.py
+++ b/tests/tensorizer_loader/test_tensorizer.py
@@ -365,6 +365,9 @@ def test_serialize_and_deserialize_lora(tmp_path):
     config_path = os.path.join(sql_lora_files, "adapter_config.json")
     tensors = load_file(tensor_path)
 
+    # TODO: This will not work for non-local saving. Use `open_stream`
+    #  to save this json. Pretty sure there are examples of this
+    #  in the tensorizer repo
     shutil.copy(config_path, tmp_path / "adapter_config.json")
 
     tensorizer_uri = tmp_path / "adapter_model.tensors"

--- a/tests/tensorizer_loader/test_tensorizer.py
+++ b/tests/tensorizer_loader/test_tensorizer.py
@@ -349,3 +349,58 @@ def test_vllm_tensorized_model_has_same_outputs(vllm_runner, tmp_path):
         # noqa: E501
 
         assert outputs == deserialized_outputs
+
+
+def test_serialize_lora_model(tmp_path):
+    from safetensors.torch import load_file
+    from vllm.lora.models import LoRAModel
+    import json
+    import shutil
+    from vllm.lora.request import LoRARequest
+    from vllm import LLM, SamplingParams
+
+    EMBEDDING_MODULES = {
+        "embed_tokens": "input_embeddings",
+        "lm_head": "output_embeddings",
+    }
+
+    EMBEDDING_PADDING_MODULES = ["lm_head"]
+
+    sql_lora_files = snapshot_download(repo_id="yard1/llama-2-7b-sql-lora-test")
+    device = "cuda"
+    tensor_path = os.path.join(sql_lora_files, "adapter_model.safetensors")
+    config_path = os.path.join(sql_lora_files, "adapter_config.json")
+    tensors = load_file(tensor_path)
+
+    shutil.copy(config_path, tmp_path / "adapter_config.json")
+
+    tensorizer_uri = tmp_path / "adapter_model.tensors"
+    serializer = TensorSerializer(tensorizer_uri)
+    serializer.write_state_dict(tensors)
+    serializer.close()
+
+
+    # Now, load it
+
+    loaded_vllm_model = LLM(model="meta-llama/Llama-2-7b-hf", enable_lora=True)
+    sampling_params = SamplingParams(
+        temperature=0,
+        max_tokens=256,
+        stop=["[/assistant]"]
+    )
+
+    prompts = [
+        "[user] Write a SQL query to answer the question based on the table schema.\n\n context: CREATE TABLE table_name_74 (icao VARCHAR, airport VARCHAR)\n\n question: Name the ICAO for lilongwe international airport [/user] [assistant]",
+        "[user] Write a SQL query to answer the question based on the table schema.\n\n context: CREATE TABLE table_name_11 (nationality VARCHAR, elector VARCHAR)\n\n question: When Anchero Pantaleone was the elector what is under nationality? [/user] [assistant]",
+    ]
+
+    lora_path = tmp_path
+    outputs = loaded_vllm_model.generate(
+        prompts,
+        sampling_params,
+        lora_request=LoRARequest("sql-lora", 1, lora_path)
+    )
+
+
+
+

--- a/tests/tensorizer_loader/test_tensorizer.py
+++ b/tests/tensorizer_loader/test_tensorizer.py
@@ -351,7 +351,7 @@ def test_vllm_tensorized_model_has_same_outputs(vllm_runner, tmp_path):
         assert outputs == deserialized_outputs
 
 
-def test_serialize_and_deserialize_lora_model(tmp_path):
+def test_serialize_and_deserialize_lora(tmp_path):
     import shutil
 
     from safetensors.torch import load_file

--- a/tests/tensorizer_loader/test_tensorizer.py
+++ b/tests/tensorizer_loader/test_tensorizer.py
@@ -109,8 +109,8 @@ def test_deserialized_encrypted_vllm_model_has_same_outputs(
 
         outputs = vllm_model.generate(prompts, sampling_params)
 
-        config_for_serializing = TensorizerConfig(tensorizer_uri=str(model_path),
-                                                  encryption_keyfile=key_path)
+        config_for_serializing = TensorizerConfig(
+            tensorizer_uri=str(model_path), encryption_keyfile=key_path)
 
         vllm_model.apply_model(
             partial(serialize_vllm_model,
@@ -168,9 +168,9 @@ def test_vllm_model_can_load_with_lora(vllm_runner, tmp_path):
         model_path = tmp_path / (model_ref + ".tensors")
 
         vllm_model.apply_model(
-            partial(
-                serialize_vllm_model,
-                tensorizer_config=TensorizerConfig(tensorizer_uri=str(model_path))))
+            partial(serialize_vllm_model,
+                    tensorizer_config=TensorizerConfig(
+                        tensorizer_uri=str(model_path))))
 
     with vllm_runner(
             model_ref,
@@ -210,9 +210,9 @@ def test_openai_apiserver_with_tensorizer(vllm_runner, tmp_path):
         model_path = tmp_path / (model_ref + ".tensors")
 
         vllm_model.apply_model(
-            partial(
-                serialize_vllm_model,
-                tensorizer_config=TensorizerConfig(tensorizer_uri=str(model_path))))
+            partial(serialize_vllm_model,
+                    tensorizer_config=TensorizerConfig(
+                        tensorizer_uri=str(model_path))))
 
         model_loader_extra_config = {
             "tensorizer_uri": str(model_path),

--- a/tests/tensorizer_loader/test_tensorizer.py
+++ b/tests/tensorizer_loader/test_tensorizer.py
@@ -109,14 +109,14 @@ def test_deserialized_encrypted_vllm_model_has_same_outputs(
 
         outputs = vllm_model.generate(prompts, sampling_params)
 
-        config_for_serializing = TensorizerConfig(tensorizer_uri=model_path,
+        config_for_serializing = TensorizerConfig(tensorizer_uri=str(model_path),
                                                   encryption_keyfile=key_path)
 
         vllm_model.apply_model(
             partial(serialize_vllm_model,
                     tensorizer_config=config_for_serializing))
 
-    config_for_deserializing = TensorizerConfig(tensorizer_uri=model_path,
+    config_for_deserializing = TensorizerConfig(tensorizer_uri=str(model_path),
                                                 encryption_keyfile=key_path)
 
     with vllm_runner(model_ref,
@@ -144,7 +144,7 @@ def test_deserialized_hf_model_has_same_outputs(hf_runner, vllm_runner,
     with vllm_runner(model_ref,
                      load_format="tensorizer",
                      model_loader_extra_config=TensorizerConfig(
-                         tensorizer_uri=model_path,
+                         tensorizer_uri=str(model_path),
                          num_readers=1,
                      )) as loaded_hf_model:
         deserialized_outputs = loaded_hf_model.generate_greedy(
@@ -170,13 +170,13 @@ def test_vllm_model_can_load_with_lora(vllm_runner, tmp_path):
         vllm_model.apply_model(
             partial(
                 serialize_vllm_model,
-                tensorizer_config=TensorizerConfig(tensorizer_uri=model_path)))
+                tensorizer_config=TensorizerConfig(tensorizer_uri=str(model_path))))
 
     with vllm_runner(
             model_ref,
             load_format="tensorizer",
             model_loader_extra_config=TensorizerConfig(
-                tensorizer_uri=model_path,
+                tensorizer_uri=str(model_path),
                 num_readers=1,
             ),
             enable_lora=True,
@@ -212,7 +212,7 @@ def test_openai_apiserver_with_tensorizer(vllm_runner, tmp_path):
         vllm_model.apply_model(
             partial(
                 serialize_vllm_model,
-                tensorizer_config=TensorizerConfig(tensorizer_uri=model_path)))
+                tensorizer_config=TensorizerConfig(tensorizer_uri=str(model_path))))
 
         model_loader_extra_config = {
             "tensorizer_uri": str(model_path),
@@ -291,7 +291,7 @@ def test_deserialized_encrypted_vllm_model_with_tp_has_same_outputs(
 
     # load model with two shards and serialize with encryption
     model_path = str(tmp_path / (model_ref + "-%02d.tensors"))
-    key_path = tmp_path / (model_ref + ".key")
+    key_path = str(tmp_path / (model_ref + ".key"))
 
     tensorizer_config = TensorizerConfig(
         tensorizer_uri=model_path,

--- a/tests/tensorizer_loader/test_tensorizer.py
+++ b/tests/tensorizer_loader/test_tensorizer.py
@@ -355,6 +355,7 @@ def test_serialize_and_deserialize_lora(tmp_path):
     lora_path = "yard1/llama-2-7b-sql-lora-test"
     model_uri = tmp_path / (model_ref + ".tensors")
     tensorizer_config = TensorizerConfig(tensorizer_uri=str(model_uri))
+    tensorizer_config.lora_dir = tensorizer_config.tensorizer_dir
     args = EngineArgs(model=model_ref)
 
     tensorize_lora_adapter(lora_path, tensorizer_config)
@@ -376,7 +377,6 @@ def test_serialize_and_deserialize_lora(tmp_path):
         "[user] Write a SQL query to answer the question based on the table schema.\n\n context: CREATE TABLE table_name_11 (nationality VARCHAR, elector VARCHAR)\n\n question: When Anchero Pantaleone was the elector what is under nationality? [/user] [assistant]",  # noqa: E501
     ]
 
-    lora_path = tensorizer_config.tensorizer_dir
     loaded_vllm_model.generate(prompts,
                                sampling_params,
                                lora_request=LoRARequest(

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -208,7 +208,11 @@ class LoRAModel(AdapterModel):
         Returns:
             Loaded LoRA Model.
         """
-        lora_tensor_path = os.path.join(lora_dir, "adapter_model.safetensors")
+
+        if os.getenv("USE_TENSORIZER_LORA") == "1":
+            lora_tensor_path = os.path.join(lora_dir, "adapter_model.tensors")
+        else:
+            lora_tensor_path = os.path.join(lora_dir, "adapter_model.safetensors")
         lora_bin_file_path = os.path.join(lora_dir, "adapter_model.bin")
         new_embeddings_tensor_path = os.path.join(
             lora_dir, "new_embeddings.safetensors")
@@ -225,24 +229,29 @@ class LoRAModel(AdapterModel):
             # loraified. C won’t exist in the safetensor but it will exist in
             # the target_modules of the adapter_config.json.
             unexpected_modules = []
-            with safetensors.safe_open(lora_tensor_path,
-                                       framework="pt") as f:  # type: ignore
-                for lora_module in f.keys():  # noqa
-                    module_name, _, _ = parse_fine_tuned_lora_name(
-                        lora_module, weights_mapper)
-                    part_name = module_name.split(".")[-1]
-                    if part_name not in expected_lora_modules:
-                        unexpected_modules.append(module_name)
-                if unexpected_modules:
-                    raise ValueError(
-                        f"While loading {lora_dir}, expected"
-                        f" target modules in {expected_lora_modules}"
-                        f" but received {unexpected_modules}."
-                        f" Please verify that the loaded LoRA module is correct"
-                    )
-                # Load tensors if there are only expected modules.
-                for module in f.keys():  # noqa
-                    tensors[module] = f.get_tensor(module)
+            if os.getenv("USE_TENSORIZER_LORA") == "1":
+                from tensorizer import TensorDeserializer
+                # TODO: Couple TensorizerConfig to this
+                tensors = TensorDeserializer(lora_tensor_path)
+            else:
+                with safetensors.safe_open(lora_tensor_path,
+                                           framework="pt") as f:  # type: ignore
+                    for lora_module in f.keys():  # noqa
+                        module_name, _, _ = parse_fine_tuned_lora_name(
+                            lora_module, weights_mapper)
+                        part_name = module_name.split(".")[-1]
+                        if part_name not in expected_lora_modules:
+                            unexpected_modules.append(module_name)
+                    if unexpected_modules:
+                        raise ValueError(
+                            f"While loading {lora_dir}, expected"
+                            f" target modules in {expected_lora_modules}"
+                            f" but received {unexpected_modules}."
+                            f" Please verify that the loaded LoRA module is correct"
+                        )
+                    # Load tensors if there are only expected modules.
+                    for module in f.keys():  # noqa
+                        tensors[module] = f.get_tensor(module)
         elif os.path.isfile(lora_bin_file_path):
             # When a bin file is provided, we rely on config to find unexpected
             # modules.

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -221,6 +221,7 @@ class LoRAModel(AdapterModel):
         new_embeddings_bin_file_path = os.path.join(lora_dir,
                                                     "new_embeddings.bin")
 
+        # TODO: This is broken due to an API change from vLLM
         if tensorizer_config:
             from tensorizer.stream_io import open_stream
             with open_stream(lora_config_path,

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -210,6 +210,8 @@ class LoRAModel(AdapterModel):
             Loaded LoRA Model.
         """
 
+        # TODO: This likely needs a better conditional here, due to the
+        #  careful nature of parsing env vars (supporting 'y', 'yes' 'Y' 'on' etc)
         if os.getenv("USE_TENSORIZER_LORA") == "1":
             lora_tensor_path = os.path.join(lora_dir, "adapter_model.tensors")
         else:

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -221,6 +221,17 @@ class LoRAModel(AdapterModel):
         new_embeddings_bin_file_path = os.path.join(lora_dir,
                                                     "new_embeddings.bin")
 
+        if tensorizer_config:
+            from tensorizer.stream_io import open_stream
+            with open_stream(lora_config_path,
+                             mode="rb",
+                             **tensorizer_args.stream_params) as f:
+                config = json.load(f)
+
+        else:
+            with open(lora_config_path) as f:
+                config = json.load(f)
+
         unexpected_modules: List[Union[list[str], str]]
         if os.path.isfile(lora_tensor_path):
             tensors: Dict[str, torch.Tensor] = {}
@@ -232,10 +243,6 @@ class LoRAModel(AdapterModel):
             # the target_modules of the adapter_config.json.
             unexpected_modules = []
             if tensorizer_config:
-                from tensorizer import TensorDeserializer
-
-                tensorizer_args = tensorizer_config._construct_tensorizer_args(
-                )
                 tensors = TensorDeserializer(
                     lora_tensor_path,
                     dtype=tensorizer_config.dtype,

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -213,7 +213,8 @@ class LoRAModel(AdapterModel):
         if os.getenv("USE_TENSORIZER_LORA") == "1":
             lora_tensor_path = os.path.join(lora_dir, "adapter_model.tensors")
         else:
-            lora_tensor_path = os.path.join(lora_dir, "adapter_model.safetensors")
+            lora_tensor_path = os.path.join(lora_dir,
+                                            "adapter_model.safetensors")
         lora_bin_file_path = os.path.join(lora_dir, "adapter_model.bin")
         new_embeddings_tensor_path = os.path.join(
             lora_dir, "new_embeddings.safetensors")
@@ -233,7 +234,8 @@ class LoRAModel(AdapterModel):
             if tensorizer_config:
                 from tensorizer import TensorDeserializer
 
-                tensorizer_args = tensorizer_config._construct_tensorizer_args()
+                tensorizer_args = tensorizer_config._construct_tensorizer_args(
+                )
                 tensors = TensorDeserializer(
                     lora_tensor_path,
                     dtype=tensorizer_config.dtype,
@@ -241,8 +243,8 @@ class LoRAModel(AdapterModel):
                     **tensorizer_args.deserializer_params)
 
             else:
-                with safetensors.safe_open(lora_tensor_path,
-                                           framework="pt") as f:  # type: ignore
+                with safetensors.safe_open(
+                        lora_tensor_path, framework="pt") as f:  # type: ignore
                     for lora_module in f.keys():  # noqa
                         module_name, _, _ = parse_fine_tuned_lora_name(
                             lora_module, weights_mapper)
@@ -254,8 +256,8 @@ class LoRAModel(AdapterModel):
                             f"While loading {lora_dir}, expected"
                             f" target modules in {expected_lora_modules}"
                             f" but received {unexpected_modules}."
-                            f" Please verify that the loaded LoRA module is correct"
-                        )
+                            f" Please verify that the loaded LoRA module "
+                            f"is correct")
                     # Load tensors if there are only expected modules.
                     for module in f.keys():  # noqa
                         tensors[module] = f.get_tensor(module)

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -37,9 +37,6 @@ logger = init_logger(__name__)
 
 _GLOBAL_LORA_ID = 0
 
-# TODO: Update docstrings for where `tensorizer_config` hooks are slotted in
-
-
 @dataclass
 class LongContextLoRAContext:
     """Context for lora adapters that support long context."""
@@ -208,6 +205,9 @@ class LoRAModel(AdapterModel):
                 a global counter.
             device: Device where the lora model is loaded.
             dtype: dtype of the lora model weights.
+            tensorizer_config: A TensorizerConfig object that, if provided,
+                can be used to load a serialized LoRAModel residing in
+                the lora_dir attribute of TensorizerConfig.
 
         Returns:
             Loaded LoRA Model.
@@ -218,8 +218,6 @@ class LoRAModel(AdapterModel):
             lora_dir, "new_embeddings.safetensors")
         new_embeddings_bin_file_path = os.path.join(lora_dir,
                                                     "new_embeddings.bin")
-
-        tensorizer_config = kwargs.get("tensorizer_config")
 
         unexpected_modules: List[Union[list[str], str]]
         tensors: Dict[str, torch.Tensor] = {}

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -224,16 +224,7 @@ class LoRAModel(AdapterModel):
                                                     "new_embeddings.bin")
 
         # TODO: This is broken due to an API change from vLLM
-        if tensorizer_config:
-            from tensorizer.stream_io import open_stream
-            with open_stream(lora_config_path,
-                             mode="rb",
-                             **tensorizer_args.stream_params) as f:
-                config = json.load(f)
-
-        else:
-            with open(lora_config_path) as f:
-                config = json.load(f)
+        tensorizer_config = kwargs.get("tensorizer_config")
 
         unexpected_modules: List[Union[list[str], str]]
         if os.path.isfile(lora_tensor_path):
@@ -246,6 +237,8 @@ class LoRAModel(AdapterModel):
             # the target_modules of the adapter_config.json.
             unexpected_modules = []
             if tensorizer_config:
+                from tensorizer import TensorDeserializer
+                tensorizer_args = tensorizer_config._construct_tensorizer_args()
                 tensors = TensorDeserializer(
                     lora_tensor_path,
                     dtype=tensorizer_config.dtype,

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -210,20 +210,13 @@ class LoRAModel(AdapterModel):
             Loaded LoRA Model.
         """
 
-        # TODO: This likely needs a better conditional here, due to the
-        #  careful nature of parsing env vars (supporting 'y', 'yes' 'Y' 'on' etc)
-        if os.getenv("USE_TENSORIZER_LORA") == "1":
-            lora_tensor_path = os.path.join(lora_dir, "adapter_model.tensors")
-        else:
-            lora_tensor_path = os.path.join(lora_dir,
-                                            "adapter_model.safetensors")
+        lora_tensor_path = os.path.join(lora_dir, "adapter_model.safetensors")
         lora_bin_file_path = os.path.join(lora_dir, "adapter_model.bin")
         new_embeddings_tensor_path = os.path.join(
             lora_dir, "new_embeddings.safetensors")
         new_embeddings_bin_file_path = os.path.join(lora_dir,
                                                     "new_embeddings.bin")
 
-        # TODO: This is broken due to an API change from vLLM
         tensorizer_config = kwargs.get("tensorizer_config")
 
         unexpected_modules: List[Union[list[str], str]]
@@ -237,7 +230,10 @@ class LoRAModel(AdapterModel):
             # the target_modules of the adapter_config.json.
             unexpected_modules = []
             if tensorizer_config:
+                # TODO: Would it be smarter to conditionally
                 from tensorizer import TensorDeserializer
+                lora_tensor_path = os.path.join(lora_dir,
+                                                "adapter_model.tensors")
                 tensorizer_args = tensorizer_config._construct_tensorizer_args()
                 tensors = TensorDeserializer(
                     lora_tensor_path,

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -37,6 +37,7 @@ logger = init_logger(__name__)
 
 _GLOBAL_LORA_ID = 0
 
+
 @dataclass
 class LongContextLoRAContext:
     """Context for lora adapters that support long context."""
@@ -178,22 +179,21 @@ class LoRAModel(AdapterModel):
                    scaling_factor=peft_helper.vllm_long_context_scaling_factor)
 
     @classmethod
-    def from_local_checkpoint(cls,
-                              lora_dir: str,
-                              expected_lora_modules: List[str],
-                              peft_helper: PEFTHelper,
-                              *,
-                              lora_model_id: Optional[int] = None,
-                              device: str = "cuda",
-                              dtype: Optional[torch.dtype] = None,
-                              target_embedding_padding: Optional[int] = None,
-                              embedding_modules: Optional[Dict[str,
-                                                               str]] = None,
-                              embedding_padding_modules: Optional[
-                                  List[str]] = None,
-                              weights_mapper: Optional[WeightsMapper] = None,
-                              tensorizer_config: Optional["TensorizerConfig"] = None
-                              ) -> "LoRAModel":
+    def from_local_checkpoint(
+            cls,
+            lora_dir: str,
+            expected_lora_modules: List[str],
+            peft_helper: PEFTHelper,
+            *,
+            lora_model_id: Optional[int] = None,
+            device: str = "cuda",
+            dtype: Optional[torch.dtype] = None,
+            target_embedding_padding: Optional[int] = None,
+            embedding_modules: Optional[Dict[str, str]] = None,
+            embedding_padding_modules: Optional[List[str]] = None,
+            weights_mapper: Optional[WeightsMapper] = None,
+            tensorizer_config: Optional["TensorizerConfig"] = None
+    ) -> "LoRAModel":
         """Create a LoRAModel from a local checkpoint.
         
         Args:
@@ -223,12 +223,15 @@ class LoRAModel(AdapterModel):
         tensors: Dict[str, torch.Tensor] = {}
         if tensorizer_config:
             from tensorizer import TensorDeserializer
-            lora_tensor_path = os.path.join(tensorizer_config.tensorizer_dir,
+            lora_tensor_path = os.path.join(tensorizer_config.lora_dir,
                                             "adapter_model.tensors")
             tensorizer_args = tensorizer_config._construct_tensorizer_args()
             tensors = TensorDeserializer(lora_tensor_path,
                                          dtype=tensorizer_config.dtype,
                                          **tensorizer_args.deserializer_params)
+            logger.info(
+                f"Successfully deserialized LoRA tensors from {tensorizer_config.lora_dir}"
+            )
 
         elif os.path.isfile(lora_tensor_path):
             # Find unexpected modules.

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -179,21 +179,21 @@ class LoRAModel(AdapterModel):
                    scaling_factor=peft_helper.vllm_long_context_scaling_factor)
 
     @classmethod
-    def from_local_checkpoint(
-        cls,
-        lora_dir: str,
-        expected_lora_modules: List[str],
-        peft_helper: PEFTHelper,
-        *,
-        lora_model_id: Optional[int] = None,
-        device: str = "cuda",
-        dtype: Optional[torch.dtype] = None,
-        target_embedding_padding: Optional[int] = None,
-        embedding_modules: Optional[Dict[str, str]] = None,
-        embedding_padding_modules: Optional[List[str]] = None,
-        weights_mapper: Optional[WeightsMapper] = None,
-        **kwargs
-    ) -> "LoRAModel":
+    def from_local_checkpoint(cls,
+                              lora_dir: str,
+                              expected_lora_modules: List[str],
+                              peft_helper: PEFTHelper,
+                              *,
+                              lora_model_id: Optional[int] = None,
+                              device: str = "cuda",
+                              dtype: Optional[torch.dtype] = None,
+                              target_embedding_padding: Optional[int] = None,
+                              embedding_modules: Optional[Dict[str,
+                                                               str]] = None,
+                              embedding_padding_modules: Optional[
+                                  List[str]] = None,
+                              weights_mapper: Optional[WeightsMapper] = None,
+                              **kwargs) -> "LoRAModel":
         """Create a LoRAModel from a local checkpoint.
         
         Args:
@@ -216,10 +216,10 @@ class LoRAModel(AdapterModel):
         new_embeddings_bin_file_path = os.path.join(lora_dir,
                                                     "new_embeddings.bin")
 
-        tensorizer_config = kwargs.get("tensorizer_config", None)
+        tensorizer_config = kwargs.get("tensorizer_config")
 
         unexpected_modules: List[Union[list[str], str]]
-
+        tensors: Dict[str, torch.Tensor] = {}
         if tensorizer_config:
             from tensorizer import TensorDeserializer
             lora_tensor_path = os.path.join(tensorizer_config.tensorizer_dir,
@@ -232,7 +232,6 @@ class LoRAModel(AdapterModel):
                 **tensorizer_args.deserializer_params)
 
         elif os.path.isfile(lora_tensor_path):
-            tensors: Dict[str, torch.Tensor] = {}
             # Find unexpected modules.
             # Use safetensor key as a source of truth to find expected modules.
             # in peft if you have target_modules A, B, C and C does not exist
@@ -240,8 +239,8 @@ class LoRAModel(AdapterModel):
             # loraified. C won’t exist in the safetensor but it will exist in
             # the target_modules of the adapter_config.json.
             unexpected_modules = []
-            with safetensors.safe_open(
-                    lora_tensor_path, framework="pt") as f:  # type: ignore
+            with safetensors.safe_open(lora_tensor_path,
+                                       framework="pt") as f:  # type: ignore
                 for lora_module in f.keys():  # noqa
                     module_name, _, _ = parse_fine_tuned_lora_name(
                         lora_module, weights_mapper)

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -231,7 +231,7 @@ class LoRAModel(AdapterModel):
             if tensorizer_config:
                 # TODO: Would it be smarter to conditionally
                 from tensorizer import TensorDeserializer
-                lora_tensor_path = os.path.join(lora_dir,
+                lora_tensor_path = os.path.join(tensorizer_config.tensorizer_dir,
                                                 "adapter_model.tensors")
                 tensorizer_args = tensorizer_config._construct_tensorizer_args()
                 tensors = TensorDeserializer(

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -195,7 +195,8 @@ class LoRAModel(AdapterModel):
                               embedding_padding_modules: Optional[
                                   List[str]] = None,
                               weights_mapper: Optional[WeightsMapper] = None,
-                              **kwargs) -> "LoRAModel":
+                              tensorizer_config: Optional["TensorizerConfig"] = None
+                              ) -> "LoRAModel":
         """Create a LoRAModel from a local checkpoint.
         
         Args:

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -37,6 +37,8 @@ logger = init_logger(__name__)
 
 _GLOBAL_LORA_ID = 0
 
+# TODO: Update docstrings for where `tensorizer_config` hooks are slotted in
+
 
 @dataclass
 class LongContextLoRAContext:
@@ -225,10 +227,9 @@ class LoRAModel(AdapterModel):
             lora_tensor_path = os.path.join(tensorizer_config.tensorizer_dir,
                                             "adapter_model.tensors")
             tensorizer_args = tensorizer_config._construct_tensorizer_args()
-            tensors = TensorDeserializer(
-                lora_tensor_path,
-                dtype=tensorizer_config.dtype,
-                **tensorizer_args.deserializer_params)
+            tensors = TensorDeserializer(lora_tensor_path,
+                                         dtype=tensorizer_config.dtype,
+                                         **tensorizer_args.deserializer_params)
 
         elif os.path.isfile(lora_tensor_path):
             # Find unexpected modules.

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -209,7 +209,6 @@ class LoRAModel(AdapterModel):
         Returns:
             Loaded LoRA Model.
         """
-
         lora_tensor_path = os.path.join(lora_dir, "adapter_model.safetensors")
         lora_bin_file_path = os.path.join(lora_dir, "adapter_model.bin")
         new_embeddings_tensor_path = os.path.join(

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -228,7 +228,6 @@ class LoRAModel(AdapterModel):
             tensors = TensorDeserializer(
                 lora_tensor_path,
                 dtype=tensorizer_config.dtype,
-                device=f'cuda:{torch.cuda.current_device()}',
                 **tensorizer_args.deserializer_params)
 
         elif os.path.isfile(lora_tensor_path):
@@ -252,8 +251,8 @@ class LoRAModel(AdapterModel):
                         f"While loading {lora_dir}, expected"
                         f" target modules in {expected_lora_modules}"
                         f" but received {unexpected_modules}."
-                        f" Please verify that the loaded LoRA module "
-                        f"is correct")
+                        f" Please verify that the loaded LoRA module is correct"
+                    )
                 # Load tensors if there are only expected modules.
                 for module in f.keys():  # noqa
                     tensors[module] = f.get_tensor(module)

--- a/vllm/lora/peft_helper.py
+++ b/vllm/lora/peft_helper.py
@@ -89,20 +89,24 @@ class PEFTHelper:
         return cls(**filtered_dict)
 
     @classmethod
-    def from_local_dir(cls, lora_path: str,
-                       max_position_embeddings: Optional[int],
-                       tensorizer_config: Optional["TensorizerConfig"]) -> "PEFTHelper":
+    def from_local_dir(
+            cls, lora_path: str, max_position_embeddings: Optional[int],
+            tensorizer_config: Optional["TensorizerConfig"]) -> "PEFTHelper":
         lora_config_path = os.path.join(lora_path, "adapter_config.json")
 
         if tensorizer_config:
             tensorizer_args = tensorizer_config._construct_tensorizer_args()
             from tensorizer.stream_io import open_stream
-            lora_config_path = os.path.join(tensorizer_config.tensorizer_dir,
+            lora_config_path = os.path.join(tensorizer_config.lora_dir,
                                             "adapter_config.json")
             with open_stream(lora_config_path,
                              mode="rb",
                              **tensorizer_args.stream_params) as f:
                 config = json.load(f)
+
+            logger.info(
+                f"Successfully deserialized LoRA config from {tensorizer_config.lora_dir}"
+            )
 
         else:
             with open(lora_config_path) as f:

--- a/vllm/lora/peft_helper.py
+++ b/vllm/lora/peft_helper.py
@@ -97,6 +97,8 @@ class PEFTHelper:
         if tensorizer_config := kwargs.get("tensorizer_config"):
             tensorizer_args = tensorizer_config._construct_tensorizer_args()
             from tensorizer.stream_io import open_stream
+            lora_config_path = os.path.join(tensorizer_config.tensorizer_dir,
+                                                "adapter_config.json")
             with open_stream(lora_config_path,
                              mode="rb",
                              **tensorizer_args.stream_params) as f:

--- a/vllm/lora/peft_helper.py
+++ b/vllm/lora/peft_helper.py
@@ -90,11 +90,22 @@ class PEFTHelper:
 
     @classmethod
     def from_local_dir(cls, lora_path: str,
-                       max_position_embeddings: Optional[int]) -> "PEFTHelper":
+                       max_position_embeddings: Optional[int],
+                       **kwargs) -> "PEFTHelper":
         lora_config_path = os.path.join(lora_path, "adapter_config.json")
 
-        with open(lora_config_path) as f:
-            config = json.load(f)
+        if tensorizer_config := kwargs.get("tensorizer_config"):
+            tensorizer_args = tensorizer_config._construct_tensorizer_args()
+            from tensorizer.stream_io import open_stream
+            with open_stream(lora_config_path,
+                             mode="rb",
+                             **tensorizer_args.stream_params) as f:
+                config = json.load(f)
+
+        else:
+            with open(lora_config_path) as f:
+                config = json.load(f)
+
         config["vllm_max_position_embeddings"] = max_position_embeddings
         return cls.from_dict(config)
 

--- a/vllm/lora/peft_helper.py
+++ b/vllm/lora/peft_helper.py
@@ -91,7 +91,7 @@ class PEFTHelper:
     @classmethod
     def from_local_dir(cls, lora_path: str,
                        max_position_embeddings: Optional[int],
-                       **kwargs) -> "PEFTHelper":
+                       tensorizer_config: Optional["TensorizerConfig"]) -> "PEFTHelper":
         lora_config_path = os.path.join(lora_path, "adapter_config.json")
 
         tensorizer_config = kwargs.get("tensorizer_config")

--- a/vllm/lora/peft_helper.py
+++ b/vllm/lora/peft_helper.py
@@ -94,12 +94,12 @@ class PEFTHelper:
                        **kwargs) -> "PEFTHelper":
         lora_config_path = os.path.join(lora_path, "adapter_config.json")
 
-        tensorizer_config = kwargs.get("tensorizer_config", None)
+        tensorizer_config = kwargs.get("tensorizer_config")
         if tensorizer_config:
             tensorizer_args = tensorizer_config._construct_tensorizer_args()
             from tensorizer.stream_io import open_stream
             lora_config_path = os.path.join(tensorizer_config.tensorizer_dir,
-                                                "adapter_config.json")
+                                            "adapter_config.json")
             with open_stream(lora_config_path,
                              mode="rb",
                              **tensorizer_args.stream_params) as f:

--- a/vllm/lora/peft_helper.py
+++ b/vllm/lora/peft_helper.py
@@ -94,7 +94,8 @@ class PEFTHelper:
                        **kwargs) -> "PEFTHelper":
         lora_config_path = os.path.join(lora_path, "adapter_config.json")
 
-        if tensorizer_config := kwargs.get("tensorizer_config"):
+        tensorizer_config = kwargs.get("tensorizer_config", None)
+        if tensorizer_config:
             tensorizer_args = tensorizer_config._construct_tensorizer_args()
             from tensorizer.stream_io import open_stream
             lora_config_path = os.path.join(tensorizer_config.tensorizer_dir,

--- a/vllm/lora/peft_helper.py
+++ b/vllm/lora/peft_helper.py
@@ -94,7 +94,6 @@ class PEFTHelper:
                        tensorizer_config: Optional["TensorizerConfig"]) -> "PEFTHelper":
         lora_config_path = os.path.join(lora_path, "adapter_config.json")
 
-        tensorizer_config = kwargs.get("tensorizer_config")
         if tensorizer_config:
             tensorizer_args = tensorizer_config._construct_tensorizer_args()
             from tensorizer.stream_io import open_stream

--- a/vllm/lora/request.py
+++ b/vllm/lora/request.py
@@ -31,7 +31,7 @@ class LoRARequest(
     lora_local_path: Optional[str] = msgspec.field(default=None)
     long_lora_max_len: Optional[int] = None
     base_model_name: Optional[str] = msgspec.field(default=None)
-    tensorizer_config: "TensorizerConfig" = None
+    tensorizer_config: "TensorizerConfig" = None  # type: ignore # noqa: F821
 
     def __post_init__(self):
         if self.lora_local_path:

--- a/vllm/lora/request.py
+++ b/vllm/lora/request.py
@@ -31,6 +31,7 @@ class LoRARequest(
     lora_local_path: Optional[str] = msgspec.field(default=None)
     long_lora_max_len: Optional[int] = None
     base_model_name: Optional[str] = msgspec.field(default=None)
+    tensorizer_config: "TensorizerConfig" = None
 
     def __post_init__(self):
         if self.lora_local_path:

--- a/vllm/lora/request.py
+++ b/vllm/lora/request.py
@@ -31,7 +31,7 @@ class LoRARequest(
     lora_local_path: Optional[str] = msgspec.field(default=None)
     long_lora_max_len: Optional[int] = None
     base_model_name: Optional[str] = msgspec.field(default=None)
-    tensorizer_config: "TensorizerConfig" = None  # type: ignore # noqa: F821
+    tensorizer_config: Optional["TensorizerConfig"] = None  # type: ignore # noqa: F821
 
     def __post_init__(self):
         if self.lora_local_path:

--- a/vllm/lora/request.py
+++ b/vllm/lora/request.py
@@ -31,7 +31,8 @@ class LoRARequest(
     lora_local_path: Optional[str] = msgspec.field(default=None)
     long_lora_max_len: Optional[int] = None
     base_model_name: Optional[str] = msgspec.field(default=None)
-    tensorizer_config: Optional["TensorizerConfig"] = None  # type: ignore # noqa: F821
+    tensorizer_config: Optional[
+        "TensorizerConfig"] = None  # mypy: ignore-errors # noqa: F821
 
     def __post_init__(self):
         if self.lora_local_path:

--- a/vllm/lora/request.py
+++ b/vllm/lora/request.py
@@ -1,11 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import typing
 import warnings
 from typing import Optional
 
 import msgspec
 
 from vllm.adapter_commons.request import AdapterRequest
+
+if typing.TYPE_CHECKING:
+    from vllm.model_executor.model_loader.tensorizer import TensorizerConfig
 
 
 class LoRARequest(
@@ -31,7 +35,7 @@ class LoRARequest(
     lora_local_path: Optional[str] = msgspec.field(default=None)
     long_lora_max_len: Optional[int] = None
     base_model_name: Optional[str] = msgspec.field(default=None)
-    tensorizer_config: Optional = None  # type: TensorizerConfig
+    tensorizer_config: Optional[TensorizerConfig] = None
 
     def __post_init__(self):
         if self.lora_local_path:

--- a/vllm/lora/request.py
+++ b/vllm/lora/request.py
@@ -31,8 +31,7 @@ class LoRARequest(
     lora_local_path: Optional[str] = msgspec.field(default=None)
     long_lora_max_len: Optional[int] = None
     base_model_name: Optional[str] = msgspec.field(default=None)
-    tensorizer_config: Optional[
-        "TensorizerConfig"] = None  # mypy: ignore-errors # noqa: F821
+    tensorizer_config: Optional = None  # type: TensorizerConfig
 
     def __post_init__(self):
         if self.lora_local_path:

--- a/vllm/lora/request.py
+++ b/vllm/lora/request.py
@@ -35,7 +35,7 @@ class LoRARequest(
     lora_local_path: Optional[str] = msgspec.field(default=None)
     long_lora_max_len: Optional[int] = None
     base_model_name: Optional[str] = msgspec.field(default=None)
-    tensorizer_config: Optional[TensorizerConfig] = None
+    tensorizer_config: Optional["TensorizerConfig"] = None
 
     def __post_init__(self):
         if self.lora_local_path:

--- a/vllm/lora/request.py
+++ b/vllm/lora/request.py
@@ -35,7 +35,8 @@ class LoRARequest(
     lora_local_path: Optional[str] = msgspec.field(default=None)
     long_lora_max_len: Optional[int] = None
     base_model_name: Optional[str] = msgspec.field(default=None)
-    tensorizer_config: Optional["TensorizerConfig"] = None
+    tensorizer_config: Optional[
+        "TensorizerConfig"] = None  # TODO: Document the usage for this
 
     def __post_init__(self):
         if self.lora_local_path:

--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -123,6 +123,7 @@ class WorkerLoRAManager(AbstractWorkerManager):
                 self.lora_config.lora_extra_vocab_size,
                 embedding_modules=self.embedding_modules,
                 embedding_padding_modules=self.embedding_padding_modules,
+                tensorizer_config=lora_request.tensorizer_config,
                 weights_mapper=hf_to_vllm_mapper)
 
         except FileNotFoundError as e:

--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -99,9 +99,10 @@ class WorkerLoRAManager(AbstractWorkerManager):
             lora_path = get_adapter_absolute_path(lora_request.lora_path)
 
             peft_helper = PEFTHelper.from_local_dir(
-                lora_path, self.max_position_embeddings,
-                tensorizer_config = getattr(lora_request, "tensorizer_config", None)
-            )
+                lora_path,
+                self.max_position_embeddings,
+                tensorizer_config=getattr(lora_request, "tensorizer_config",
+                                          None))
 
             # Validates the LoRA configuration against requirements before
             # loading weights, throwing an exception if validation fails.

--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -99,7 +99,9 @@ class WorkerLoRAManager(AbstractWorkerManager):
             lora_path = get_adapter_absolute_path(lora_request.lora_path)
 
             peft_helper = PEFTHelper.from_local_dir(
-                lora_path, self.max_position_embeddings)
+                lora_path, self.max_position_embeddings,
+                tensorizer_config = getattr(lora_request, "tensorizer_config", None)
+            )
 
             # Validates the LoRA configuration against requirements before
             # loading weights, throwing an exception if validation fails.

--- a/vllm/model_executor/model_loader/tensorizer.py
+++ b/vllm/model_executor/model_loader/tensorizer.py
@@ -468,12 +468,13 @@ def tensorize_vllm_model(engine_args: EngineArgs,
         kwargs=dict(tensorizer_config=tensorizer_config),
     )
 
+
 def tensorize_lora_adapter(lora_path: str,
-                         tensorizer_config: TensorizerConfig):
-    from huggingface_hub import snapshot_download
-    from safetensors.torch import load_file
+                           tensorizer_config: TensorizerConfig):
     import shutil
 
+    from huggingface_hub import snapshot_download
+    from safetensors.torch import load_file
 
     # TODO: Consider if the model tensors are in an initial format
     #  other than safetensors, such as .pt
@@ -486,15 +487,12 @@ def tensorize_lora_adapter(lora_path: str,
     config_path = os.path.join(lora_files, "adapter_config.json")
     tensors = load_file(tensor_path)
 
-    shutil.copy(
-        config_path,
-        f"{tensorizer_config.tensorizer_dir}"
-    )
+    shutil.copy(config_path, f"{tensorizer_config.tensorizer_dir}")
     lora_uri = (f"{tensorizer_config.tensorizer_dir}"
-                                        f"/adapter_model.tensors")
+                f"/adapter_model.tensors")
     tensorizer_args = tensorizer_config._construct_tensorizer_args()
     with open_stream(lora_uri, mode="wb+",
-                    **tensorizer_args.stream_params) as f:
+                     **tensorizer_args.stream_params) as f:
         serializer = TensorSerializer(f)
         serializer.write_state_dict(tensors)
         serializer.close()

--- a/vllm/model_executor/model_loader/tensorizer.py
+++ b/vllm/model_executor/model_loader/tensorizer.py
@@ -474,6 +474,14 @@ def tensorize_vllm_model(engine_args: EngineArgs,
 
 def tensorize_lora_adapter(lora_path: str,
                            tensorizer_config: TensorizerConfig):
+    """
+    Uses tensorizer to serialize a LoRA adapter. Assumes that the files
+    needed to load a LoRA adapter are a safetensors-format file called
+    adapter_model.safetensors and a json config file called adapter_config.json.
+
+    Serializes the files in the same directory as model tensors located at
+    tensorizer_config.tensorizer_uri.
+    """
     lora_files = snapshot_download(repo_id=lora_path)
 
     # Current LoRA loading logic in

--- a/vllm/model_executor/model_loader/tensorizer.py
+++ b/vllm/model_executor/model_loader/tensorizer.py
@@ -474,14 +474,13 @@ def tensorize_vllm_model(engine_args: EngineArgs,
 
 def tensorize_lora_adapter(lora_path: str,
                            tensorizer_config: TensorizerConfig):
-
-    # TODO: Consider if the model tensors are in an initial format
-    #  other than safetensors, such as .pt
-    # TODO: Is there a guarantee the adapter_model and adapter_config
-    #  prefixes are the ones that will always used? Probably allow
-    #  specifying paths for these files
-
     lora_files = snapshot_download(repo_id=lora_path)
+
+    # Current LoRA loading logic in
+    # vllm.lora.models.LoRAModel.from_local_checkpoint assumes that
+    # the tensors and config filenames are adapter_model.safetensors and
+    # adapter_config.json respectively, so this logic makes the same
+    # assumption
     tensor_path = os.path.join(lora_files, "adapter_model.safetensors")
     config_path = os.path.join(lora_files, "adapter_config.json")
     with open(config_path) as f:

--- a/vllm/model_executor/model_loader/tensorizer.py
+++ b/vllm/model_executor/model_loader/tensorizer.py
@@ -76,6 +76,7 @@ class TensorizerConfig:
         # check if the configuration is for a sharded vLLM model
         self._is_sharded = isinstance(self.tensorizer_uri, str) \
             and re.search(r'%0\dd', self.tensorizer_uri) is not None
+        self.tensorizer_dir = self.tensorizer_uri.rpartition("/")[0]
 
     def _construct_tensorizer_args(self) -> "TensorizerArgs":
         tensorizer_args = {

--- a/vllm/model_executor/model_loader/tensorizer.py
+++ b/vllm/model_executor/model_loader/tensorizer.py
@@ -467,3 +467,34 @@ def tensorize_vllm_model(engine_args: EngineArgs,
         "save_tensorized_model",
         kwargs=dict(tensorizer_config=tensorizer_config),
     )
+
+def tensorize_lora_adapter(lora_path: str,
+                         tensorizer_config: TensorizerConfig):
+    from huggingface_hub import snapshot_download
+    from safetensors.torch import load_file
+    import shutil
+
+
+    # TODO: Consider if the model tensors are in an initial format
+    #  other than safetensors, such as .pt
+    # TODO: Is there a guarantee the adapter_model and adapter_config
+    #  prefixes are the ones that will always used? Probably allow
+    #  specifying paths for these files
+
+    lora_files = snapshot_download(repo_id=lora_path)
+    tensor_path = os.path.join(lora_files, "adapter_model.safetensors")
+    config_path = os.path.join(lora_files, "adapter_config.json")
+    tensors = load_file(tensor_path)
+
+    shutil.copy(
+        config_path,
+        f"{tensorizer_config.tensorizer_dir}"
+    )
+    lora_uri = (f"{tensorizer_config.tensorizer_dir}"
+                                        f"/adapter_model.tensors")
+    tensorizer_args = tensorizer_config._construct_tensorizer_args()
+    with open_stream(lora_uri, mode="wb+",
+                    **tensorizer_args.stream_params) as f:
+        serializer = TensorSerializer(f)
+        serializer.write_state_dict(tensors)
+        serializer.close()

--- a/vllm/model_executor/model_loader/tensorizer.py
+++ b/vllm/model_executor/model_loader/tensorizer.py
@@ -79,7 +79,8 @@ class TensorizerConfig:
         # check if the configuration is for a sharded vLLM model
         self._is_sharded = isinstance(self.tensorizer_uri, str) \
             and re.search(r'%0\dd', self.tensorizer_uri) is not None
-        self.tensorizer_dir = self.tensorizer_uri.rpartition("/")[0]
+        self.tensorizer_dir = self.tensorizer_uri.rpartition("/")[
+            0]  # TODO: use os.path.dirname
 
     def _construct_tensorizer_args(self) -> "TensorizerArgs":
         tensorizer_args = {
@@ -493,7 +494,9 @@ def tensorize_lora_adapter(lora_path: str,
     config_path = os.path.join(lora_files, "adapter_config.json")
     with open(config_path) as f:
         config = json.load(f)
-    tensors = load_file(tensor_path)
+    tensors = load_file(
+        tensor_path
+    )  # TODO: make this safetensors.torch.load_file() for clarity
 
     tensorizer_args = tensorizer_config._construct_tensorizer_args()
 


### PR DESCRIPTION
# Serializing and deserializing LoRA adapters using `tensorizer`
This PR allows LoRA adapters to be serialized and deserialized using `tensorizer`. A test is added to confirm this and serializing LoRA files can be done with the same script that can save vLLM models in `examples/tensorize_vllm_model.py`.

## Summary of changes

- Adjusted the CLI args for `.buildkite/test-pipeline.yaml`'s invocation of the `tensorize_vllm_model.py` example script to additionally save and load a LoRA adapter, testing a model generation after deserialization to confirm the LoRA adapter was loaded properly
- Added `--lora-path` to `tensorize_vllm_model.py` as a base argparser argument that allows a user to specify the HuggingFace reference ID for a LoRA adapter, which can be either serialized or deserialized depending on whether the `serialize` or `deserialize` subparser is indicated.
- Added `test_serialize_and_deserialize_lora` to `test_tensorizer.py` testing saving and loading LoRA adapters with `tensorizer`.
- Allows deserializing a LoRA adapter by allowing `TensorizerConfig` to be passed in as a kwarg to `LoRARequest`. When this is done, the LoRA tensors are assumed to be in `tensorizer` format and deserialized according to the parameters given in the `TensorizerConfig` provided.


**Note**: Noticed a few things that need hotfixes after putting up this PR. Stamped `TODO`s on these and working on them now while waiting for reviews. If you still see any `TODO`'s (which means I haven't addressed them yet) please do feel free to comment on them.

~NB: In addition, **an extra planned change** will be added to their test pipeline, which will have OpenAI API inference engine `tensorizer` support tests to ensure these can be part of fast-check for forward-compatibility. As such, the state of this PR is not final and will warrant a further review once that piece is added (may be more appropriate to draft this but a review is warranted on the current state).~ This has been added in [cc3f984](https://github.com/coreweave/vllm/pull/3/commits/cc3f98474f0cad362c2556ea37484d5f3e36630b)