### PR TITLE
feat: Allow passing arbitrary Tensorizer serialization and deserialization kwargs; update docs

### DIFF
--- a/docs/models/extensions/tensorizer.md
+++ b/docs/models/extensions/tensorizer.md
@@ -77,12 +77,14 @@ one can simply do:
 vllm serve s3://my-bucket/vllm/facebook/opt-125m/v1 --load-format=tensorizer
 ```
 
-Please note that authentication to S3 is still required. Tensorizer will 
-automatically look for a `~/.s3cfg` or `~/.aws/config` and `~/.aws/credentials`
-file locally to authenticate, but also can be given the environment variables 
-`AWS_ACCESS_KEY_ID` or `S3_ACCESS_KEY_ID` for the object storage access key,
-`AWS_SECRET_ACCESS_KEY` or `S3_SECRET_ACCESS_KEY` for the object storage 
-secret key, and `AWS_S3_ENDPOINT_URL` or `S3_ENDPOINT_URL` for the endpoint url.
+Please note that object storage authentication is still required.
+To authenticate, Tensorizer searches for a `~/.s3cfg` configuration file
+([s3cmd](https://s3tools.org/kb/item14.htm)'s format),
+or `~/.aws/config` and `~/.aws/credentials` files (`boto3` and the
+`aws` CLI's format), but authentication can also be configured using
+[any normal `boto3` environment variables](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-environment-variables),
+such as `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
+and `AWS_ENDPOINT_URL_S3`.
 
 If only the model tensors are saved, you can still provide that as the only 
 artifact in your directory to load from, and vLLM will fetch the rest using the 

--- a/docs/models/extensions/tensorizer.md
+++ b/docs/models/extensions/tensorizer.md
@@ -8,9 +8,70 @@ vLLM model tensors that have been serialized to disk, an HTTP/HTTPS endpoint, or
 at runtime extremely quickly directly to the GPU, resulting in significantly
 shorter Pod startup times and CPU memory usage. Tensor encryption is also supported.
 
-For more information on CoreWeave's Tensorizer, please refer to
-[CoreWeave's Tensorizer documentation](https://github.com/coreweave/tensorizer). For more information on serializing a vLLM model, as well a general usage guide to using Tensorizer with vLLM, see
-the [vLLM example script](https://docs.vllm.ai/en/latest/examples/tensorize_vllm_model.html).
+vLLM fully integrates Tensorizer in to its model loading machinery. The 
+following will give a brief overview on how to get started with using 
+Tensorizer on vLLM.
+
+## The basics
+To load a model using Tensorizer, it first needs to be serialized by Tensorizer.
+The example script in [examples/others/tensorize_vllm_model.py] takes care of 
+this process.
+(https://github.com/vllm-project/vllm/blob/main/examples/others/tensorize_vllm_model.py)
+
+Let's walk through a basic example by serializing `facebook/opt-125m` using the
+script, and then loading it for inference.
+
+## Saving a vLLM model with Tensorizer
+To save a model with Tensorizer, call the example script with the necessary
+CLI arguments. The docstring for the script itself explains the CLI args
+and how to use it properly in great detail, and we'll use one of the 
+examples from the docstring directly, assuming we want to save our model at 
+our S3 bucket example `s3://my-bucket`:
+
+```bash
+python examples/others/tensorize_vllm_model.py \
+   --model facebook/opt-125m \
+   serialize \
+   --serialized-directory s3://my-bucket \
+   --suffix v1
+```
+
+This saves the model tensors at `s3://my-bucket/vllm/facebook/opt-125m/v1`.
+
+## Serving the model using Tensorizer
+Once the model is serialized where you want it, you need to pass
+`--load-format=tensorizer` as well as a JSON string to the 
+`--model-loader-extra-config` CLI arg for `vllm serve`, specifying 
+all the keyword arguments you'd normally pass to the `TensorizerConfig` 
+initializer, as if you were instantiating it like this, for instance: 
+`TensorizerConfig(**{"tensorizer_uri": "foo"})`. Here's an example bash 
+script that neatly lays out the JSON string before passing it to 
+`--model-loader-extra-config`:
+
+```bash
+#!/bin/bash
+
+read -r -d '' JSON << EOF
+{
+  "tensorizer_uri": "s3://my-bucket/vllm/facebook/opt-125m/v1/model.tensors",
+  "stream_kwargs": {"force_http": "False"},
+  "deserialization_kwargs": {"verify_hash": "True", "num_readers": 8}
+}
+EOF
+
+MODEL_LOADER_EXTRA_CONFIG=$(echo "$JSON" | tr -d '\n')
+
+vllm serve facebook/opt-125m \
+  --load-format=tensorizer \
+  --model-loader-extra-config="$MODEL_LOADER_EXTRA_CONFIG"
+```
+
+Note in this case, if the directory to the model artifacts at 
+`s3://my-bucket/vllm/facebook/opt-125m/v1/` doesn't at least have a `config.
+json` file, you'll want to pass `facebook/opt-125m` as the model tag like 
+it was done in the example script above. In our example, we just added a 
+`model.tensors` file to that directory. In this case, vLLM will take care of 
+resolving the other model artifacts using HF Hub.
 
 !!! note
     Note that to use this feature you will need to install `tensorizer` by running `pip install vllm[tensorizer]`.

--- a/docs/models/extensions/tensorizer.md
+++ b/docs/models/extensions/tensorizer.md
@@ -86,10 +86,9 @@ or `~/.aws/config` and `~/.aws/credentials` files (`boto3` and the
 such as `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
 and `AWS_ENDPOINT_URL_S3`.
 
-If only the model tensors are saved, you can still provide that as the only 
-artifact in your directory to load from, and vLLM will fetch the rest using the 
-`--model-loader-extra-config` CLI arg, passing a JSON string with the args 
-for `TensorizerConfig`.
+If only the `model.tensors` file exists, you can load exclusively that file
+by using the `--model-loader-extra-config` CLI parameter, which expects a
+JSON string with all the kwargs for a `TensorizerConfig` configuration object.
 
 ```bash
 #!/bin/sh

--- a/docs/models/extensions/tensorizer.md
+++ b/docs/models/extensions/tensorizer.md
@@ -8,7 +8,7 @@ vLLM model tensors that have been serialized to disk, an HTTP/HTTPS endpoint, or
 at runtime extremely quickly directly to the GPU, resulting in significantly
 lower Pod startup times and CPU memory usage. Tensor encryption is also supported.
 
-vLLM fully integrates Tensorizer in to its model loading machinery. The
+vLLM fully integrates Tensorizer in its model loading machinery. The
 following will give a brief overview on how to get started with using
 Tensorizer on vLLM.
 
@@ -74,7 +74,6 @@ pass that directory with the model artifacts to `vllm serve` in the case above,
 one can simply do:
 
 ```bash
-#!/bin/bash
 vllm serve s3://my-bucket/vllm/facebook/opt-125m/v1 --load-format=tensorizer
 ```
 
@@ -91,7 +90,7 @@ artifact in your directory to load from, and vLLM will fetch the rest using the
 for `TensorizerConfig`.
 
 ```bash
-#!/bin/bash
+#!/bin/sh
 
 MODEL_LOADER_EXTRA_CONFIG='{
   "tensorizer_uri": "s3://my-bucket/vllm/facebook/opt-125m/v1/model.tensors",

--- a/docs/models/extensions/tensorizer.md
+++ b/docs/models/extensions/tensorizer.md
@@ -62,7 +62,8 @@ python examples/others/tensorize_vllm_model.py \
    --suffix v1
 ```
 
-This saves the model tensors at `s3://my-bucket/vllm/facebook/opt-125m/v1`.
+This saves the model tensors at 
+`s3://my-bucket/vllm/facebook/opt-125m/v1/model.tensors`.
 
 ## Serving the model using Tensorizer
 Once the model is serialized where you want it, you need to pass

--- a/docs/models/extensions/tensorizer.md
+++ b/docs/models/extensions/tensorizer.md
@@ -8,15 +8,14 @@ vLLM model tensors that have been serialized to disk, an HTTP/HTTPS endpoint, or
 at runtime extremely quickly directly to the GPU, resulting in significantly
 shorter Pod startup times and CPU memory usage. Tensor encryption is also supported.
 
-vLLM fully integrates Tensorizer in to its model loading machinery. The 
-following will give a brief overview on how to get started with using 
+vLLM fully integrates Tensorizer in to its model loading machinery. The
+following will give a brief overview on how to get started with using
 Tensorizer on vLLM.
 
 ## The basics
 To load a model using Tensorizer, it first needs to be serialized by Tensorizer.
-The example script in [examples/others/tensorize_vllm_model.py] takes care of 
-this process.
-(https://github.com/vllm-project/vllm/blob/main/examples/others/tensorize_vllm_model.py)
+The example script in [examples/others/tensorize_vllm_model.py](https://github.com/vllm-project/vllm/blob/main/examples/others/tensorize_vllm_model.py)
+takes care of this process.
 
 Let's walk through a basic example by serializing `facebook/opt-125m` using the
 script, and then loading it for inference.
@@ -24,8 +23,8 @@ script, and then loading it for inference.
 ## Saving a vLLM model with Tensorizer
 To save a model with Tensorizer, call the example script with the necessary
 CLI arguments. The docstring for the script itself explains the CLI args
-and how to use it properly in great detail, and we'll use one of the 
-examples from the docstring directly, assuming we want to save our model at 
+and how to use it properly in great detail, and we'll use one of the
+examples from the docstring directly, assuming we want to save our model at
 our S3 bucket example `s3://my-bucket`:
 
 ```bash
@@ -40,12 +39,12 @@ This saves the model tensors at `s3://my-bucket/vllm/facebook/opt-125m/v1`.
 
 ## Serving the model using Tensorizer
 Once the model is serialized where you want it, you need to pass
-`--load-format=tensorizer` as well as a JSON string to the 
-`--model-loader-extra-config` CLI arg for `vllm serve`, specifying 
-all the keyword arguments you'd normally pass to the `TensorizerConfig` 
-initializer, as if you were instantiating it like this, for instance: 
-`TensorizerConfig(**{"tensorizer_uri": "foo"})`. Here's an example bash 
-script that neatly lays out the JSON string before passing it to 
+`--load-format=tensorizer` as well as a JSON string to the
+`--model-loader-extra-config` CLI arg for `vllm serve`, specifying
+all the keyword arguments you'd normally pass to the `TensorizerConfig`
+initializer, as if you were instantiating it like this, for instance:
+`TensorizerConfig(**{"tensorizer_uri": "foo"})`. Here's an example bash
+script that neatly lays out the JSON string before passing it to
 `--model-loader-extra-config`:
 
 ```bash
@@ -66,11 +65,11 @@ vllm serve facebook/opt-125m \
   --model-loader-extra-config="$MODEL_LOADER_EXTRA_CONFIG"
 ```
 
-Note in this case, if the directory to the model artifacts at 
+Note in this case, if the directory to the model artifacts at
 `s3://my-bucket/vllm/facebook/opt-125m/v1/` doesn't at least have a `config.
-json` file, you'll want to pass `facebook/opt-125m` as the model tag like 
-it was done in the example script above. In our example, we just added a 
-`model.tensors` file to that directory. In this case, vLLM will take care of 
+json` file, you'll want to pass `facebook/opt-125m` as the model tag like
+it was done in the example script above. In our example, we just added a
+`model.tensors` file to that directory. In this case, vLLM will take care of
 resolving the other model artifacts using HF Hub.
 
 !!! note

--- a/docs/models/extensions/tensorizer.md
+++ b/docs/models/extensions/tensorizer.md
@@ -6,7 +6,7 @@ title: Loading models with CoreWeave's Tensorizer
 vLLM supports loading models with [CoreWeave's Tensorizer](https://docs.coreweave.com/coreweave-machine-learning-and-ai/inference/tensorizer).
 vLLM model tensors that have been serialized to disk, an HTTP/HTTPS endpoint, or S3 endpoint can be deserialized
 at runtime extremely quickly directly to the GPU, resulting in significantly
-shorter Pod startup times and CPU memory usage. Tensor encryption is also supported.
+lower Pod startup times and CPU memory usage. Tensor encryption is also supported.
 
 vLLM fully integrates Tensorizer in to its model loading machinery. The
 following will give a brief overview on how to get started with using

--- a/docs/models/extensions/tensorizer.md
+++ b/docs/models/extensions/tensorizer.md
@@ -17,8 +17,35 @@ To load a model using Tensorizer, it first needs to be serialized by Tensorizer.
 The example script in [examples/others/tensorize_vllm_model.py](https://github.com/vllm-project/vllm/blob/main/examples/others/tensorize_vllm_model.py)
 takes care of this process.
 
-Let's walk through a basic example by serializing `facebook/opt-125m` using the
-script, and then loading it for inference.
+The core frontend object of note integrating Tensorizer is 
+`TensorizerConfig`, defined [here](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/model_loader/tensorizer.py#L135-L214)
+It's a config object holding important state and passed to any serialization 
+or deserialization operation. When loading with Tensorizer using the vLLM 
+library rather than through a model-serving entrypoint, it gets passed to 
+the `LLM` entrypoint class directly. Here's an example of loading a model
+saved at `"s3://my-bucket/vllm/facebook/opt-125m/v1/model.tensors"`.
+
+```python
+from vllm import LLM
+from vllm.model_executor.model_loader.tensorizer import TensorizerConfig
+
+path_to_tensors = "s3://my-bucket/vllm/facebook/opt-125m/v1/model.tensors"
+
+model_ref = "facebook/opt-125m"
+tensorizer_config = TensorizerConfig(
+        tensorizer_uri=path_to_tensors,
+    )
+
+llm = LLM(
+    model_ref,
+    load_format="tensorizer",
+    model_loader_extra_config=tensorizer_config,
+)
+```
+
+But that code won't work unless you actually have your serialized model 
+tensors `model.tensors`, so let's walk through a basic example of serializing 
+`facebook/opt-125m` using the example script, and then loading it for inference.
 
 ## Saving a vLLM model with Tensorizer
 To save a model with Tensorizer, call the example script with the necessary

--- a/examples/others/tensorize_vllm_model.py
+++ b/examples/others/tensorize_vllm_model.py
@@ -171,6 +171,14 @@ def parse_args():
         "provided.")
 
     serialize_parser.add_argument(
+        "--serialization-kwargs",
+        type=str,
+        required=False,
+        help=("A JSON string containing additional keyword arguments that "
+              "will be passed to Tensorizer's `TensorSerializer` during "
+              "serialization."))
+
+    serialize_parser.add_argument(
         "--keyfile",
         type=str,
         required=False,
@@ -294,6 +302,12 @@ if __name__ == '__main__':
             tensorizer_uri=model_path,
             encryption_keyfile=keyfile,
             **credentials)
+
+        if args.serialization_kwargs:
+            serialization_kwargs = json.loads(args.serialization_kwargs)
+            tensorizer_config.serialization_kwargs = serialization_kwargs
+            print("Found serialization kwargs: ", serialization_kwargs)
+
 
         if args.lora_path:
             tensorizer_config.lora_dir = tensorizer_config.tensorizer_dir

--- a/examples/others/tensorize_vllm_model.py
+++ b/examples/others/tensorize_vllm_model.py
@@ -210,7 +210,7 @@ def parse_args():
         required=False,
         help=("A JSON string containing additional keyword arguments to "
               "pass to Tensorizer's `TensorDeserializer` during "
-              "serialization."))
+              "deserialization."))
 
     TensorizerArgs.add_cli_args(deserialize_parser)
 

--- a/examples/others/tensorize_vllm_model.py
+++ b/examples/others/tensorize_vllm_model.py
@@ -174,8 +174,8 @@ def parse_args():
         "--serialization-kwargs",
         type=str,
         required=False,
-        help=("A JSON string containing additional keyword arguments that "
-              "will be passed to Tensorizer's `TensorSerializer` during "
+        help=("A JSON string containing additional keyword arguments to "
+              "pass to Tensorizer's `TensorSerializer` during "
               "serialization."))
 
     serialize_parser.add_argument(
@@ -306,8 +306,6 @@ if __name__ == '__main__':
         if args.serialization_kwargs:
             serialization_kwargs = json.loads(args.serialization_kwargs)
             tensorizer_config.serialization_kwargs = serialization_kwargs
-            print("Found serialization kwargs: ", serialization_kwargs)
-
 
         if args.lora_path:
             tensorizer_config.lora_dir = tensorizer_config.tensorizer_dir

--- a/tests/entrypoints/openai/test_tensorizer_entrypoint.py
+++ b/tests/entrypoints/openai/test_tensorizer_entrypoint.py
@@ -59,12 +59,18 @@ def tensorize_model_and_lora(tmp_dir, model_uri):
 def server(model_uri, tensorize_model_and_lora):
     model_loader_extra_config = {
         "tensorizer_uri": model_uri,
+        "stream_kwargs": {
+            "force_http": False,
+        },
+        "deserialization_kwargs": {
+            "verify_hash": True,
+            "num_readers": 8,
+        }
     }
 
     ## Start OpenAI API server
     args = [
-        "--load-format", "tensorizer", "--device", "cuda",
-        "--model-loader-extra-config",
+        "--load-format", "tensorizer", "--model-loader-extra-config",
         json.dumps(model_loader_extra_config), "--enable-lora"
     ]
 

--- a/tests/lora/test_llama_tp.py
+++ b/tests/lora/test_llama_tp.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import subprocess
 import sys
+import json
 from typing import Union
 
 import pytest
@@ -210,7 +211,8 @@ def test_tp2_serialize_and_deserialize_lora(tmp_path, sql_lora_files,
             f"{VLLM_PATH}/examples/others/tensorize_vllm_model.py", "--model",
             MODEL_PATH, "--lora-path", lora_path, "--tensor-parallel-size",
             str(tp_size), "serialize", "--serialized-directory",
-            str(tmp_path), "--suffix", suffix
+            str(tmp_path), "--suffix", suffix, "--serialization-kwargs",
+            json.dumps({"limit_cpu_concurrency": 4})
         ],
                                 check=True,
                                 capture_output=True,

--- a/tests/lora/test_llama_tp.py
+++ b/tests/lora/test_llama_tp.py
@@ -212,7 +212,7 @@ def test_tp2_serialize_and_deserialize_lora(tmp_path, sql_lora_files,
             MODEL_PATH, "--lora-path", lora_path, "--tensor-parallel-size",
             str(tp_size), "serialize", "--serialized-directory",
             str(tmp_path), "--suffix", suffix, "--serialization-kwargs",
-            json.dumps({"limit_cpu_concurrency": 4})
+            '{"limit_cpu_concurrency": 4}'
         ],
                                 check=True,
                                 capture_output=True,

--- a/tests/tensorizer_loader/conftest.py
+++ b/tests/tensorizer_loader/conftest.py
@@ -7,11 +7,20 @@ import os
 from vllm import LLM
 from vllm.distributed import cleanup_dist_env_and_memory
 from vllm.model_executor.model_loader.tensorizer import TensorizerConfig
+from vllm.utils import get_distributed_init_method, get_open_port, get_ip
+
+from vllm.v1.engine.core import EngineCore
+from vllm.v1.executor.abstract import UniProcExecutor
+from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.outputs import ModelRunnerOutput
+from vllm.v1.worker.gpu_worker import Worker
+from vllm.worker.worker_base import WorkerWrapperBase
 
 
 @pytest.fixture(autouse=True)
-def allow_insecure_serialization():
+def allow_insecure_serialization(monkeypatch):
     os.environ["VLLM_ALLOW_INSECURE_SERIALIZATION"] = "1"
+    monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
 
 @pytest.fixture(autouse=True)
 def cleanup():
@@ -29,3 +38,43 @@ def assert_from_collective_rpc(engine: LLM,
                                closure_kwargs: dict):
     res = engine.collective_rpc(method=closure, kwargs=closure_kwargs)
     return all(res)
+
+
+class DummyExecutor(UniProcExecutor):
+
+    def _init_executor(self) -> None:
+        """Initialize the worker and load the model.
+        """
+        self.driver_worker = WorkerWrapperBase(
+            vllm_config=self.vllm_config,
+            rpc_rank=0
+            )
+        distributed_init_method = get_distributed_init_method(
+            get_ip(), get_open_port()
+        )
+        local_rank = 0
+        # set local rank as the device index if specified
+        device_info = self.vllm_config.device_config.device.__str__().split(
+            ":"
+        )
+        if len(device_info) > 1:
+            local_rank = int(device_info[1])
+        rank = 0
+        is_driver_worker = True
+        kwargs = dict(
+            vllm_config=self.vllm_config,
+            local_rank=local_rank,
+            rank=rank,
+            distributed_init_method=distributed_init_method,
+            is_driver_worker=is_driver_worker,
+        )
+        self.collective_rpc("init_worker", args=([kwargs],))
+        self.collective_rpc("init_device")
+
+    @property
+    def max_concurrent_batches(self) -> int:
+        return 2
+
+    def shutdown(self):
+        if hasattr(self, 'thread_pool'):
+            self.thread_pool.shutdown(wait=False)

--- a/tests/tensorizer_loader/conftest.py
+++ b/tests/tensorizer_loader/conftest.py
@@ -39,6 +39,10 @@ def assert_from_collective_rpc(engine: LLM,
     return all(res)
 
 
+# This is an object pulled from tests/v1/engine/test_engine_core.py
+# Modified to strip the `load_model` method from its `_init_executor`
+# method. It's purely used as a dummy utility to run methods that test
+# Tensorizer functionality
 class DummyExecutor(UniProcExecutor):
 
     def _init_executor(self) -> None:

--- a/tests/tensorizer_loader/conftest.py
+++ b/tests/tensorizer_loader/conftest.py
@@ -19,7 +19,6 @@ from vllm.worker.worker_base import WorkerWrapperBase
 
 @pytest.fixture(autouse=True)
 def allow_insecure_serialization(monkeypatch):
-    os.environ["VLLM_ALLOW_INSECURE_SERIALIZATION"] = "1"
     monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
 
 @pytest.fixture(autouse=True)

--- a/tests/tensorizer_loader/conftest.py
+++ b/tests/tensorizer_loader/conftest.py
@@ -1,9 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
-import pytest
+from typing import Callable
 
+import pytest
+import os
+
+from vllm import LLM
 from vllm.distributed import cleanup_dist_env_and_memory
 from vllm.model_executor.model_loader.tensorizer import TensorizerConfig
 
+
+@pytest.fixture(autouse=True)
+def allow_insecure_serialization():
+    os.environ["VLLM_ALLOW_INSECURE_SERIALIZATION"] = "1"
 
 @pytest.fixture(autouse=True)
 def cleanup():
@@ -14,3 +22,10 @@ def cleanup():
 def tensorizer_config():
     config = TensorizerConfig(tensorizer_uri="vllm")
     return config
+
+
+def assert_from_collective_rpc(engine: LLM,
+                               closure: Callable,
+                               closure_kwargs: dict):
+    res = engine.collective_rpc(method=closure, kwargs=closure_kwargs)
+    return all(res)

--- a/tests/tensorizer_loader/test_tensorizer.py
+++ b/tests/tensorizer_loader/test_tensorizer.py
@@ -296,7 +296,7 @@ def test_assert_serialization_kwargs_passed_to_tensor_serializer(tmp_path):
     }
     model_ref = "facebook/opt-125m"
     model_path = tmp_path / (model_ref + ".tensors")
-    config = TensorizerConfig(tensorizer_uri=str(model_path), serialization_kwargs=serialization_params, _debug=True)
+    config = TensorizerConfig(tensorizer_uri=str(model_path), serialization_kwargs=serialization_params)
     llm = LLM(
         model=model_ref,
         device="cuda",

--- a/tests/tensorizer_loader/test_tensorizer.py
+++ b/tests/tensorizer_loader/test_tensorizer.py
@@ -75,7 +75,6 @@ def patch_init_and_catch_error(self, obj, method, expected_error: Exception):
 
     def wrapper(*args, **kwargs):
         try:
-            breakpoint()
             return original(*args, **kwargs)
         except expected_error:
             raise TensorizerCaughtError

--- a/tests/tensorizer_loader/test_tensorizer.py
+++ b/tests/tensorizer_loader/test_tensorizer.py
@@ -325,8 +325,7 @@ def test_assert_serialization_kwargs_passed_to_tensor_serializer(tmp_path):
 
         tensorizer.serialization.TensorSerializer.__init__ = tensorizer_serializer_wrapper
 
-        tensorizer_config = TensorizerConfig(**kwargs.get("tensorizer_config"))
-        assert tensorizer_config is not None
+        tensorizer_config = TensorizerConfig(**kwargs["tensorizer_config"])
         self.save_tensorized_model(
             tensorizer_config=tensorizer_config, )
         return to_compare | original_dict == to_compare
@@ -434,7 +433,7 @@ async def test_serialize_and_serve_entrypoints(tmp_path):
             f"{VLLM_PATH}/examples/others/tensorize_vllm_model.py", "--model",
             model_ref, "serialize", "--serialized-directory",
             str(tmp_path), "--suffix", suffix, "--serialization-kwargs",
-            json.dumps({"limit_cpu_concurrency": 4})
+            '{"limit_cpu_concurrency": 4}'
         ],
                                 check=True,
                                 capture_output=True,
@@ -474,12 +473,10 @@ async def test_serialize_and_serve_entrypoints(tmp_path):
     try:
         async with asyncio.timeout(180):
             await proc.stdout.readuntil(b"Application startup complete.")
-
     except asyncio.TimeoutError:
         pytest.fail("Server did not start successfully")
-
-
-    proc.terminate()
+    finally:
+        proc.terminate()
     await proc.communicate()
 
 

--- a/tests/tensorizer_loader/test_tensorizer.py
+++ b/tests/tensorizer_loader/test_tensorizer.py
@@ -441,6 +441,8 @@ def test_serialize_and_serve_entrypoints(tmp_path):
         print("STDERR:\n", e.stderr)
         raise
 
+    print("Serializing STDOUT:\n", result.stdout)
+
     # Next, try to serve with vllm serve
     model_uri = tmp_path / "vllm" / model_ref / suffix / "model.tensors"
 
@@ -469,3 +471,5 @@ def test_serialize_and_serve_entrypoints(tmp_path):
         print("STDOUT:\n", e.stdout)
         print("STDERR:\n", e.stderr)
         raise
+
+    print("vLLM Serving STDOUT:\n", result.stdout)

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -54,7 +54,7 @@ def parse_type(return_type: Callable[[str], T]) -> Callable[[str], T]:
 
     def _parse_type(val: str) -> T:
         try:
-            if return_type is json.loads and not re.match("^{.*}$", val):
+            if return_type is json.loads and not re.match(r"(?s)^\s*{.*}\s*$", val):
                 return cast(T, nullable_kvs(val))
             return return_type(val)
         except ValueError as e:
@@ -76,7 +76,7 @@ def optional_type(
 
 
 def union_dict_and_str(val: str) -> Optional[Union[str, dict[str, str]]]:
-    if not re.match("^{.*}$", val):
+    if not re.match(r"(?s)^\s*{.*}\s*$", val):
         return str(val)
     return optional_type(json.loads)(val)
 

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -246,7 +246,7 @@ class LoRAModel(AdapterModel):
             tensorizer_args = tensorizer_config._construct_tensorizer_args()
             tensors = TensorDeserializer(lora_tensor_path,
                                          dtype=tensorizer_config.dtype,
-                                         **tensorizer_args.deserializer_params)
+                                         **tensorizer_args.deserialization_kwargs)
             check_unexpected_modules(tensors)
 
         elif os.path.isfile(lora_tensor_path):

--- a/vllm/lora/peft_helper.py
+++ b/vllm/lora/peft_helper.py
@@ -105,7 +105,7 @@ class PEFTHelper:
                                             "adapter_config.json")
             with open_stream(lora_config_path,
                              mode="rb",
-                             **tensorizer_args.stream_params) as f:
+                             **tensorizer_args.stream_kwargs) as f:
                 config = json.load(f)
 
             logger.info("Successfully deserialized LoRA config from %s",

--- a/vllm/model_executor/model_loader/tensorizer.py
+++ b/vllm/model_executor/model_loader/tensorizer.py
@@ -146,6 +146,7 @@ class TensorizerConfig:
     hf_config: Optional[PretrainedConfig] = None
     dtype: Optional[Union[str, torch.dtype]] = None
     lora_dir: Optional[str] = None
+    stream_kwargs: Optional[dict[str, Any]] = None
     serialization_kwargs: Optional[dict[str, Any]] = None
     deserialization_kwargs: Optional[dict[str, Any]] = None
     _is_sharded: bool = False
@@ -185,6 +186,7 @@ class TensorizerConfig:
             "s3_access_key_id": self.s3_access_key_id,
             "s3_secret_access_key": self.s3_secret_access_key,
             "s3_endpoint": self.s3_endpoint,
+            "stream_kwargs": self.stream_kwargs,
             "serialization_kwargs": self.serialization_kwargs,
             "deserialization_kwargs": self.deserialization_kwargs,
         }
@@ -233,6 +235,7 @@ class TensorizerArgs:
     s3_access_key_id: Optional[str] = None
     s3_secret_access_key: Optional[str] = None
     s3_endpoint: Optional[str] = None
+    stream_kwargs: Optional[dict[str, Any]] = None
     deserialization_kwargs: Optional[dict[str, Any]] = None
     serialization_kwargs: Optional[dict[str, Any]] = None
     """
@@ -272,6 +275,11 @@ class TensorizerArgs:
           be set via the S3_SECRET_ACCESS_KEY environment variable.
       s3_endpoint: The endpoint for the S3 bucket. Can also be set via the
           S3_ENDPOINT_URL environment variable.
+      stream_kwargs: Arbitrary keyword arguments to pass to Tensorizer's
+          `stream_io` object, which the `TensorSeriaizer` and 
+          TensorDeserializer` objects use to work with streams.
+          See the Tensorizer page in vLLM's official documentation for more 
+          information on available kwargs.
       deserialization_kwargs: Additional keyword arguments to be passed 
           directly to Tensorizer's `TensorDeserializer`. See the Tensorizer
           page in vLLM's official documentation for more information on 
@@ -293,6 +301,8 @@ class TensorizerArgs:
             "s3_secret_access_key": self.s3_secret_access_key,
             "s3_endpoint": self.s3_endpoint,
         }
+        if self.stream_kwargs:
+            self.stream_params.update(**self.stream_kwargs)
 
 
         if self.encryption_keyfile:

--- a/vllm/model_executor/model_loader/tensorizer.py
+++ b/vllm/model_executor/model_loader/tensorizer.py
@@ -69,6 +69,7 @@ def tensorizer_kwargs_arg(value):
             f"deserialization_kwargs must be "
             f"deserializable from a JSON string to a dictionary. "
         )
+    return loaded
 
 class MetaTensorMode(TorchDispatchMode):
 

--- a/vllm/model_executor/model_loader/tensorizer.py
+++ b/vllm/model_executor/model_loader/tensorizer.py
@@ -264,15 +264,20 @@ class TensorizerArgs:
           inferred as vLLM models.
       verify_hash: If True, the hashes of each tensor will be verified against 
           the hashes stored in the metadata. A `HashMismatchError` will be 
-          raised if any of the hashes do not match. Deprecated, as this can 
-          now be passed along with any other `TensorDeserializer` kwargs 
-          through `deserialization_kwargs`.
+          raised if any of the hashes do not match. Passing parameters 
+          to TensorizerSerializer and TensorDeserializer objects explicitly
+          in TensorizerArgs and TensorizerConfig is deprecated. This parameter 
+          and others that are given to TensorDeserializer should now be 
+          provided in the deserialization_kwargs dict.
       num_readers: Controls how many threads are allowed to read concurrently
           from the source file. Default is `None`, which will dynamically set
           the number of readers based on the number of available.
           resources and model size. This greatly increases performance.
-          Deprecated, as this can now be passed along with any other 
-          `TensorDeserializer` kwargs through `deserialization_kwargs`.
+          Passing parameters to TensorizerSerializer and TensorDeserializer 
+          objects explicitly in TensorizerArgs and TensorizerConfig is 
+          deprecated. This parameter and others that are given to 
+          TensorDeserializer should now be provided in the 
+          deserialization_kwargs dict.
       encryption_keyfile: File path to a binary file containing a  
           binary key to use for decryption. `None` (the default) means 
           no decryption. See the example script in 

--- a/vllm/model_executor/model_loader/tensorizer.py
+++ b/vllm/model_executor/model_loader/tensorizer.py
@@ -61,6 +61,14 @@ __all__ = [
 
 logger = init_logger(__name__)
 
+def tensorizer_kwargs_arg(value):
+    loaded = json.loads(value)
+    if not isinstance(loaded, dict):
+        raise argparse.ArgumentTypeError(
+            f"Not deserializable to dict: {value}. serialization_kwargs and "
+            f"deserialization_kwargs must be "
+            f"deserializable from a JSON string to a dictionary. "
+        )
 
 class MetaTensorMode(TorchDispatchMode):
 

--- a/vllm/model_executor/model_loader/tensorizer.py
+++ b/vllm/model_executor/model_loader/tensorizer.py
@@ -275,9 +275,9 @@ class TensorizerArgs:
           be set via the S3_SECRET_ACCESS_KEY environment variable.
       s3_endpoint: The endpoint for the S3 bucket. Can also be set via the
           S3_ENDPOINT_URL environment variable.
-      stream_kwargs: Arbitrary keyword arguments to pass to Tensorizer's
-          `stream_io` object, which the `TensorSeriaizer` and 
-          TensorDeserializer` objects use to work with streams.
+      stream_kwargs: Keyword arguments to pass to Tensorizer's
+          `stream_io.open_stream()` function, which the `TensorSerializer` and
+          `TensorDeserializer` objects use to work with files and streams.
           See the Tensorizer page in vLLM's official documentation for more 
           information on available kwargs.
       deserialization_kwargs: Additional keyword arguments to be passed 

--- a/vllm/model_executor/model_loader/tensorizer_loader.py
+++ b/vllm/model_executor/model_loader/tensorizer_loader.py
@@ -19,6 +19,19 @@ from vllm.model_executor.model_loader.utils import (get_model_architecture,
 
 logger = init_logger(__name__)
 
+BLACKLISTED_TENSORIZER_ARGS = {
+    "device", # vLLM decides this
+    "dtype",  # vLLM decides this
+    "mode",   # Not meant to be configurable by the user
+}
+
+def validate_config(config: dict):
+    for k, v in config.items():
+        if v is not None and k in BLACKLISTED_TENSORIZER_ARGS:
+            raise ValueError(
+                f"{k} is not an allowed Tensorizer argument."
+            )
+
 
 class TensorizerLoader(BaseModelLoader):
     """Model loader using CoreWeave's tensorizer library."""
@@ -28,6 +41,7 @@ class TensorizerLoader(BaseModelLoader):
         if isinstance(load_config.model_loader_extra_config, TensorizerConfig):
             self.tensorizer_config = load_config.model_loader_extra_config
         else:
+            validate_config(load_config.model_loader_extra_config)
             self.tensorizer_config = TensorizerConfig(
                 **load_config.model_loader_extra_config)
 


### PR DESCRIPTION
Feature adding the following to the [sangstar/tensorizer-aws-update-and-any-kwargs](https://github.com/coreweave/vllm/tree/sangstar/tensorizer-aws-update-and-any-kwargs) branch, which aims to add:

- Exposing arbitrary kwargs to Tensorizer from vLLM
- Harmonizing Tensorizer's AWS-style boto3 support with vLLM's
- Updating the docs to reflect these changes, greatly expanding upon the intended usage pattern so users can read it and immediately know how to get started

This is the kwargs-update portion. This PR adds:
- Exposing arbitrary kwargs to `TensorSerializer` and `TensorDeserializer`, adding tests to confirm functionality
- Update docs thoroughly to reflect straight-forward usage, including the new changes. The docs are not finished yet, as they'll be updated with the AWS-update feature to be included in the eventual PR for the aforementioned branch.

The changes herein are succinctly described in a snippet to the updated docs, describing how to load a model using Tensorizer with the updated arbitrary kwargs without too much pain in constructing the JSON string. The kwargs here are just throwaways demonstrating the support.

```bash
#!/bin/sh

MODEL_LOADER_EXTRA_CONFIG='{
  "tensorizer_uri": "s3://my-bucket/vllm/facebook/opt-125m/v1/model.tensors",
  "stream_kwargs": {"force_http": false},
  "deserialization_kwargs": {"verify_hash": true, "num_readers": 8}
}'

vllm serve facebook/opt-125m \
  --load-format=tensorizer \
  --model-loader-extra-config="$MODEL_LOADER_EXTRA_CONFIG"
```

_Please hold off on any requests for changes relating to formatting. This will all be done in a later stage with vLLM's formatter._