### PR TITLE
feat: Allow serializing and deserializing with Tensorizer without passing `--model-loader-extra-config`

### DIFF
--- a/examples/others/tensorize_vllm_model.py
+++ b/examples/others/tensorize_vllm_model.py
@@ -185,8 +185,16 @@ def parse_args():
     deserialize_parser.add_argument(
         "--path-to-tensors",
         type=str,
-        required=True,
+        required=False,
         help="The local path or S3 URI to the model tensors to deserialize. ")
+
+    deserialize_parser.add_argument(
+        "--tensorized-dir",
+        type=str,
+        required=False,
+        help="Directory with model artifacts for loading. Assumes a "
+             "model.tensors file exists therein. Can supersede "
+             "--path-to-tensors.")
 
     deserialize_parser.add_argument(
         "--keyfile",
@@ -302,7 +310,13 @@ if __name__ == '__main__':
         tensorize_vllm_model(engine_args, tensorizer_config)
 
     elif args.command == "deserialize":
+        if not args.path_to_tensors and not args.tensorized_dir:
+            raise ValueError("Must provide either path_to_tensors "
+                             "or tensorized_dir")
         if not tensorizer_args:
+            if args.tensorized_dir:
+                tensorized_dir = args.tensorized_dir
+
             tensorizer_config = TensorizerConfig(
                 tensorizer_uri=args.path_to_tensors,
                 encryption_keyfile = keyfile,

--- a/tests/entrypoints/openai/test_tensorizer_entrypoint.py
+++ b/tests/entrypoints/openai/test_tensorizer_entrypoint.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import gc
 import json
+import os
 import tempfile
 
 import openai
@@ -57,18 +58,21 @@ def tensorize_model_and_lora(tmp_dir, model_uri):
 
 @pytest.fixture(scope="module")
 def server(model_uri, tensorize_model_and_lora):
-    model_loader_extra_config = {
-        "tensorizer_uri": model_uri,
-    }
+    # In this case, model_uri is a directory with a model.tensors
+    # file and all necessary model artifacts, particularly a
+    # HF `config.json` file. In this case, Tensorizer can infer the
+    # `TensorizerConfig` so --model-loader-extra-config can be completely
+    # omitted.
+
 
     ## Start OpenAI API server
     args = [
-        "--load-format", "tensorizer", "--device", "cuda",
-        "--model-loader-extra-config",
-        json.dumps(model_loader_extra_config), "--enable-lora"
+        "--load-format", "tensorizer", "--served-model-name", MODEL_NAME,
+        "--enable-lora"
     ]
 
-    with RemoteOpenAIServer(MODEL_NAME, args) as remote_server:
+    model_dir = os.path.dirname(model_uri)
+    with RemoteOpenAIServer(model_dir, args) as remote_server:
         yield remote_server
 
 

--- a/tests/lora/test_llama_tp.py
+++ b/tests/lora/test_llama_tp.py
@@ -236,7 +236,7 @@ def test_tp2_serialize_and_deserialize_lora(tmp_path, sql_lora_files,
                             tensor_parallel_size=2,
                             max_loras=2)
 
-    tensorizer_config_dict = tensorizer_config.to_dict()
+    tensorizer_config_dict = tensorizer_config.to_serializable()
 
     print("lora adapter created")
     assert do_sample(loaded_vllm_model,

--- a/tests/tensorizer_loader/conftest.py
+++ b/tests/tensorizer_loader/conftest.py
@@ -1,13 +1,39 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
+import os
 
+from vllm import EngineArgs
 from vllm.distributed import cleanup_dist_env_and_memory
 from vllm.model_executor.model_loader.tensorizer import TensorizerConfig
+from vllm.model_executor.model_loader import tensorizer as tensorizer_mod
 
+MODEL_REF = "facebook/opt-125m"
+tensorize_model_for_testing_script = os.path.join(
+    os.path.dirname(__file__), "tensorize_vllm_model_for_testing.py")
+
+@pytest.fixture()
+def model_ref():
+    return MODEL_REF
 
 @pytest.fixture(autouse=True)
 def cleanup():
     cleanup_dist_env_and_memory(shutdown_ray=True)
+
+
+@pytest.fixture()
+def just_serialize_model_tensors(model_ref, monkeypatch, tmp_path):
+
+    def noop(*args, **kwargs):
+        return None
+
+    args = EngineArgs(model=model_ref)
+    tc = TensorizerConfig(tensorizer_uri = f"{tmp_path}/model.tensors")
+
+    monkeypatch.setattr(tensorizer_mod, "serialize_extra_artifacts", noop)
+
+    tensorizer_mod.tensorize_vllm_model(args, tc)
+    yield tmp_path
+
 
 
 @pytest.fixture(autouse=True)

--- a/tests/tensorizer_loader/conftest.py
+++ b/tests/tensorizer_loader/conftest.py
@@ -8,8 +8,6 @@ from vllm.model_executor.model_loader.tensorizer import TensorizerConfig
 from vllm.model_executor.model_loader import tensorizer as tensorizer_mod
 
 MODEL_REF = "facebook/opt-125m"
-tensorize_model_for_testing_script = os.path.join(
-    os.path.dirname(__file__), "tensorize_vllm_model_for_testing.py")
 
 @pytest.fixture()
 def model_ref():
@@ -40,3 +38,8 @@ def just_serialize_model_tensors(model_ref, monkeypatch, tmp_path):
 def tensorizer_config():
     config = TensorizerConfig(tensorizer_uri="vllm")
     return config
+
+
+@pytest.fixture()
+def model_path(model_ref, tmp_path):
+    yield tmp_path / model_ref / "model.tensors"

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -636,8 +636,7 @@ class ModelConfig:
             # If tokenizer is same as model, download to same directory
             if model == tokenizer:
                 s3_model.pull_files(
-                    model, ignore_pattern=["*.pt", "*.safetensors", "*.bin"
-                                            "*.tensors"])
+                    model, ignore_pattern=["*.pt", "*.safetensors", "*.bin", "*.tensors"])
                 self.tokenizer = s3_model.dir
                 return
 
@@ -645,7 +644,7 @@ class ModelConfig:
         if is_s3(tokenizer):
             s3_tokenizer = S3Model()
             s3_tokenizer.pull_files(
-                model, ignore_pattern=["*.pt", "*.safetensors", "*.bin"])
+                model, ignore_pattern=["*.pt", "*.safetensors", "*.bin", "*.tensors"])
             self.tokenizer = s3_tokenizer.dir
 
     def _init_multimodal_config(self) -> Optional["MultiModalConfig"]:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -914,9 +914,15 @@ class EngineArgs:
         )
 
     def no_valid_tensorizer_args_in_model_loader_extra_config(self) -> bool:
+
         if self.model_loader_extra_config:
-            keys = self.model_loader_extra_config.keys()
-            return "tensorizer_uri" not in keys and "tensorizer_dir" not in keys
+            for allowed_to_pass in ["tensorizer_uri", "tensorizer_dir"]:
+                try:
+                    logger.info("Got %s", self.model_loader_extra_config)
+                    self.model_loader_extra_config[allowed_to_pass]
+                    return False
+                except KeyError:
+                    pass
         return True
 
     def create_load_config(self) -> LoadConfig:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -911,7 +911,6 @@ class EngineArgs:
             override_generation_config=self.override_generation_config,
             enable_sleep_mode=self.enable_sleep_mode,
             model_impl=self.model_impl,
-            using_tensorizer=self.load_format == LoadFormat.TENSORIZER,
         )
 
     def create_load_config(self) -> LoadConfig:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -911,12 +911,20 @@ class EngineArgs:
             override_generation_config=self.override_generation_config,
             enable_sleep_mode=self.enable_sleep_mode,
             model_impl=self.model_impl,
+            using_tensorizer=self.load_format == LoadFormat.TENSORIZER,
         )
 
     def create_load_config(self) -> LoadConfig:
 
         if self.quantization == "bitsandbytes":
             self.load_format = "bitsandbytes"
+
+        if self.load_format == "tensorizer" and not self.model_loader_extra_config:
+            # In this instance, infer TensorizerConfig.tensorizer_dir from the
+            # model tag.
+            self.model_loader_extra_config = {
+                "tensorizer_dir": self.model
+            }
 
         return LoadConfig(
             load_format=self.load_format,

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -245,7 +245,7 @@ class LoRAModel(AdapterModel):
                                             "adapter_model.tensors")
             tensorizer_args = tensorizer_config._construct_tensorizer_args()
             tensors = TensorDeserializer(lora_tensor_path,
-                                         dtype=tensorizer_config.dtype,
+                                         dtype=tensorizer_config._model_cls_dtype,
                                          **tensorizer_args.deserializer_params)
             check_unexpected_modules(tensors)
 

--- a/vllm/model_executor/model_loader/tensorizer.py
+++ b/vllm/model_executor/model_loader/tensorizer.py
@@ -542,12 +542,6 @@ def is_vllm_tensorized(tensorizer_config: "TensorizerConfig") -> bool:
 def serialize_extra_artifacts(tensorizer_args: TensorizerArgs,
                               model_config: ModelConfig) -> None:
 
-    # TODO: New pseudocode:
-    #       1. snapshot_download model_ref to tmpdir, EXCLUDE TENSORS,
-    #       so if there's some *.pt, *.safetensors, *.bin exclude pattern
-    #       I can pass, great. -- there's a ignore_patterns thing
-    #       2. Write that entire tmpdir to S3
-
     exclusion_suffixes = [".cache", ".gitattributes", ".md"]
     should_exclude = lambda file: any(suffix in file for suffix in exclusion_suffixes)
 

--- a/vllm/model_executor/model_loader/tensorizer.py
+++ b/vllm/model_executor/model_loader/tensorizer.py
@@ -282,6 +282,9 @@ class TensorizerConfig:
         return open_stream(self.tensorizer_uri,
                            **tensorizer_args.stream_params)
 
+    def __getitem__(self, item: str) -> Any:
+        return getattr(self, item)
+
 
 def load_with_tensorizer(tensorizer_config: TensorizerConfig,
                          **extra_kwargs) -> nn.Module:

--- a/vllm/model_executor/model_loader/tensorizer.py
+++ b/vllm/model_executor/model_loader/tensorizer.py
@@ -5,6 +5,7 @@ import contextlib
 import contextvars
 import dataclasses
 import io
+from pathlib import Path
 import json
 import os
 import tempfile

--- a/vllm/model_executor/model_loader/tensorizer_loader.py
+++ b/vllm/model_executor/model_loader/tensorizer_loader.py
@@ -113,10 +113,12 @@ class TensorizerLoader(BaseModelLoader):
     def save_model(
         model: torch.nn.Module,
         tensorizer_config: Union[TensorizerConfig, dict],
+        model_config: ModelConfig,
     ) -> None:
         if isinstance(tensorizer_config, dict):
             tensorizer_config = TensorizerConfig(**tensorizer_config)
         serialize_vllm_model(
             model=model,
             tensorizer_config=tensorizer_config,
+            model_config=model_config,
         )

--- a/vllm/model_executor/model_loader/tensorizer_loader.py
+++ b/vllm/model_executor/model_loader/tensorizer_loader.py
@@ -79,9 +79,9 @@ class TensorizerLoader(BaseModelLoader):
                 model_class = get_model_architecture(model_config)[0]
 
                 tensorizer_config = copy.copy(self.tensorizer_config)
-                tensorizer_config.model_class = model_class
-                tensorizer_config.hf_config = model_config.hf_config
-                tensorizer_config.dtype = model_config.dtype
+                tensorizer_config._model_cls = model_class
+                tensorizer_config._hf_config = model_config.hf_config
+                tensorizer_config._model_cls_dtype = model_config.dtype
 
                 model = load_with_tensorizer(tensorizer_config,
                                              vllm_config=vllm_config)

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -269,7 +269,6 @@ def get_config(
 ) -> PretrainedConfig:
     # Separate model folder from file path for GGUF models
 
-    using_tensorizer = kwargs.get("using_tensorizer", False)
     is_gguf = check_gguf_file(model)
     if is_gguf:
         kwargs["gguf_file"] = Path(model).name
@@ -277,7 +276,7 @@ def get_config(
 
     if config_format == ConfigFormat.AUTO:
         try:
-            if is_gguf or using_tensorizer or file_or_path_exists(
+            if is_gguf or file_or_path_exists(
                     model, HF_CONFIG_NAME, revision=revision):
                 config_format = ConfigFormat.HF
             elif file_or_path_exists(model,
@@ -308,12 +307,6 @@ def get_config(
             raise ValueError(error_message) from e
 
     if config_format == ConfigFormat.HF:
-        if using_tensorizer:
-            from vllm.model_executor.model_loader.tensorizer import \
-                deserialize_hf_model_artifacts_to_path
-            temp_dir_with_cfg = deserialize_hf_model_artifacts_to_path(model)
-            model = os.path.join(temp_dir_with_cfg.name, "config.json")
-
         config_dict, _ = PretrainedConfig.get_config_dict(
             model,
             revision=revision,

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -269,6 +269,7 @@ def get_config(
 ) -> PretrainedConfig:
     # Separate model folder from file path for GGUF models
 
+    using_tensorizer = kwargs.get("using_tensorizer", False)
     is_gguf = check_gguf_file(model)
     if is_gguf:
         kwargs["gguf_file"] = Path(model).name
@@ -276,7 +277,7 @@ def get_config(
 
     if config_format == ConfigFormat.AUTO:
         try:
-            if is_gguf or file_or_path_exists(
+            if is_gguf or using_tensorizer or file_or_path_exists(
                     model, HF_CONFIG_NAME, revision=revision):
                 config_format = ConfigFormat.HF
             elif file_or_path_exists(model,
@@ -307,6 +308,12 @@ def get_config(
             raise ValueError(error_message) from e
 
     if config_format == ConfigFormat.HF:
+        if using_tensorizer:
+            from vllm.model_executor.model_loader.tensorizer import \
+                deserialize_hf_model_artifacts_to_path
+            temp_dir_with_cfg = deserialize_hf_model_artifacts_to_path(model)
+            model = os.path.join(temp_dir_with_cfg.name, "config.json")
+
         config_dict, _ = PretrainedConfig.get_config_dict(
             model,
             revision=revision,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1558,6 +1558,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         TensorizerLoader.save_model(
             self.model,
             tensorizer_config=tensorizer_config,
+            model_config=self.model_config
         )
 
     def _get_prompt_logprobs_dict(

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -1245,6 +1245,7 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
         TensorizerLoader.save_model(
             self.model,
             tensorizer_config=tensorizer_config,
+            model_config=self.model_config,
         )
 
     def get_max_block_per_batch(self) -> int:


### PR DESCRIPTION
# Serializing and deserializing with Tensorizer just with AWS config/credential files or env vars
This PR streamlines Tensorizer usage patterns with vLLM by allowing Tensorizer to handle model loading (and saving) from vLLM just by passing `load_format=tensorizer`.

As a basic demonstrating of what this looks like, the targets being run in this `Makefile` demonstrate the ways Tensorizer can be used to now save and load models without passing things like `--model-loader-extra-config` JSON strings.

```Makefile
SHELL := /bin/bash
PYTHON := $(shell python3 -c 'import sys; print(sys.executable)')
SERIALIZATION_FP := /vllm-workspace/examples/others/tensorize_vllm_model.py
WITH_PDB := -m pdb
AWS_ENDPOINT_URL := https://cwobject.com/
ENV := AWS_ACCESS_KEY_ID=$(AWS_ACCESS_KEY_ID) AWS_SECRET_ACCESS_KEY=$(AWS_SECRET_ACCESS_KEY) AWS_ENDPOINT_URL=$(AWS_ENDPOINT_URL)

.PHONY: test_serialize_env_vars test_serialize_aws_cfg test_vllm_serve_with_aws_cfg test_vllm_serve_with_aws_env_vars

test_serialize_env_vars:
	@$(ENV) $(PYTHON) $(SERIALIZATION_FP) \
		--model facebook/opt-125m \
		serialize \
		--serialized-directory s3://ml-dev-sandbox-bucket \
		--suffix v1

# Assumes aws config and creds files are in ~/.aws/* as they are conventionally
test_serialize_aws_cfg:
	$(PYTHON) $(SERIALIZATION_FP) \
			--model facebook/opt-125m \
			serialize \
			--serialized-directory s3://ml-dev-sandbox-bucket \
			--suffix v1

test_vllm_serve_with_aws_cfg:
	@$(ENV) AWS_S3_ADDRESSING_STYLE=virtual $(PYTHON) -m vllm.entrypoints.cli.main serve s3://ml-dev-sandbox-bucket/vllm/facebook/opt-125m/v1 \
		--load-format=tensorizer

test_vllm_serve_with_aws_env_vars:
	@$(ENV) AWS_S3_ADDRESSING_STYLE=virtual $(PYTHON) -m vllm.entrypoints.cli.main serve s3://ml-dev-sandbox-bucket/vllm/facebook/opt-125m/v1 \
		--load-format=tensorizer
```

_Please hold off on any requests for changes relating to formatting. This will all be done in a later stage with vLLM's formatter._